### PR TITLE
Hide search results when navigating to channel claim search result

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -3394,9 +3394,11 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             //fragment.setRetainInstance(true);
             FragmentManager manager = getSupportFragmentManager();
 
+            if (fragment instanceof FileViewFragment || fragment instanceof ChannelFragment)
+                findViewById(R.id.fragment_container_search).setVisibility(View.GONE);
+
             FragmentTransaction transaction;
             if (fragment instanceof FileViewFragment) {
-                findViewById(R.id.fragment_container_search).setVisibility(View.GONE);
                 transaction = manager.beginTransaction().replace(R.id.main_activity_other_fragment, fragment, "FileView");
             } else {
                 transaction = manager.beginTransaction().replace(R.id.main_activity_other_fragment, fragment);

--- a/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
@@ -289,7 +289,7 @@ public class SearchFragment extends BaseFragment implements
                 params.put("suggestedUrl", claim.getName());
 //                activity.openFragment(PublishFragment.class, true, NavMenuItem.ID_ITEM_NEW_PUBLISH, params);
             } else if (claim.getName().startsWith("@")) {
-                activity.openChannelUrl(claim.getPermanentUrl());
+                activity.openChannelClaim(claim);
             } else {
                 // not a channel
                 activity.openFileClaim(claim);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
When trying to open a channel claim from search results, results fragment is not hidden, so activity looks split into 2 sections, not allowiing to completelly see channel fragment
## What is the new behavior?
Search results is hidden