### PR TITLE
Show "no notifications" UI when there is no signed in user

### DIFF
--- a/app/src/main/java/com/odysee/app/supplier/GetLocalNotificationsSupplier.java
+++ b/app/src/main/java/com/odysee/app/supplier/GetLocalNotificationsSupplier.java
@@ -1,0 +1,29 @@
+package com.odysee.app.supplier;
+
+import android.database.sqlite.SQLiteDatabase;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import com.odysee.app.data.DatabaseHelper;
+import com.odysee.app.model.lbryinc.LbryNotification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class GetLocalNotificationsSupplier implements Supplier<List<LbryNotification>> {
+    @Override
+    public List<LbryNotification> get() {
+        List<LbryNotification> notifications = new ArrayList<>();
+        DatabaseHelper dbHelper = DatabaseHelper.getInstance();
+        try {
+            SQLiteDatabase db = dbHelper.getReadableDatabase();
+            notifications = DatabaseHelper.getNotifications(db);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return notifications;
+    }
+}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Refactoring (no functional changes)

## Fixes

Issue Number: #1 

## What is the current behavior?
After user has signed out, notifications are still being shown
## What is the new behavior?
After account has been removed from device, notification list and count is now empty
## Other information
This PR is also refactoring the code to get local notifications. It is now using Java Future API, as AsyncTask is deprecated and, in this particular case, memory leak could occur.