### PR TITLE
Remove "Decentralize" references when requesting data

### DIFF
--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -26,7 +26,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:fontFamily="@font/inter"
-                android:text="@string/loading_decentralized_data"
+                android:text="@string/loading_content"
                 android:textSize="16sp"
                 android:textFontWeight="300" />
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -27,7 +27,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:fontFamily="@font/inter"
-                android:text="@string/loading_decentralized_data"
+                android:text="@string/loading_content"
                 android:textSize="16sp"
                 android:textFontWeight="300" />
         </LinearLayout>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Descarrega</string>
     <string name="open">Obre</string>
     <string name="report">Denuncia</string>
-    <string name="loading_decentralized_data">Carregant dades descentralitzades...</string>
     <string name="related_content">Contingut relacionat</string>
     <string name="comments">Comentaris</string>
     <string name="no_comments">No hi ha comentaris per mostrar en aquest moment.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -55,7 +55,6 @@
     <string name="download">Download</string>
     <string name="open">Öffnen</string>
     <string name="report">Melden</string>
-    <string name="loading_decentralized_data">Lade dezentralisierte Daten...</string>
     <string name="related_content">Ähnliche Inhalte</string>
     <string name="comments">Kommentare</string>
     <string name="no_comments">Derzeit gibt es keine anzeigbaren Kommentare.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Descargar</string>
     <string name="open">Abrir</string>
     <string name="report">Reportar</string>
-    <string name="loading_decentralized_data">Cargando datos descentralizados...</string>
     <string name="related_content">Contenido Relacionado</string>
     <string name="comments">Comentarios</string>
     <string name="no_comments">No hay comentarios para mostrar en este momento.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Télécharger</string>
     <string name="open">Ouvrir</string>
     <string name="report">Rapport</string>
-    <string name="loading_decentralized_data">Chargement des données décentralisées…</string>
     <string name="related_content">Contenu connexe</string>
     <string name="comments">Commentaires</string>
     <string name="no_comments">Aucun commentaire à afficher pour le moment.</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">הורד</string>
     <string name="open">פתח</string>
     <string name="report">דווח</string>
-    <string name="loading_decentralized_data">טוען מידע מבוזר…</string>
     <string name="related_content">תכנים דומים</string>
     <string name="comments">תגובות</string>
     <string name="no_comments">אין תגובות להצגה בזמן זה.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">डाउनलोड</string>
     <string name="open">खोलें</string>
     <string name="report">रिपोर्ट</string>
-    <string name="loading_decentralized_data">विकेन्द्रीकृत डेटा लोड हो रहा है ...</string>
     <string name="related_content">संबंधित सामग्री</string>
     <string name="comments">टिप्पणियां</string>
     <string name="no_comments">इस समय प्रदर्शित करने के लिए कोई कमेंट्स नहीं हैं।</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Unduh</string>
     <string name="open">Buka</string>
     <string name="report">Laporkan</string>
-    <string name="loading_decentralized_data">Memuat data desentralisasi...</string>
     <string name="related_content">Konten terkait</string>
     <string name="comments">Komentar</string>
     <string name="no_comments">Tidak ada komentar untuk ditampilkan saat ini.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Scarica</string>
     <string name="open">Apri</string>
     <string name="report">Segnala</string>
-    <string name="loading_decentralized_data">Caricamento dati decentralizzati...</string>
     <string name="related_content">Contenuti connessi</string>
     <string name="comments">Commenti</string>
     <string name="no_comments">Nessun commento al momento.</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Download</string>
     <string name="open">Bukak</string>
     <string name="report">Laporane</string>
-    <string name="loading_decentralized_data">Nemokake data sing disentralisasi...</string>
     <string name="related_content">Konten sing gegandhengan</string>
     <string name="comments">Komentar</string>
     <string name="no_comments">Ora komentar sing ditampilake ing wektu iki.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Muat-turun</string>
     <string name="open">Buka</string>
     <string name="report">Lapor</string>
-    <string name="loading_decentralized_data">Memuatkan data terdesentralisasi ...</string>
     <string name="related_content">Kandungan Berkaitan</string>
     <string name="comments">Komen</string>
     <string name="no_comments">Tiada komen buat masa ini</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Pobierz</string>
     <string name="open">Otwórz</string>
     <string name="report">Zgłoś</string>
-    <string name="loading_decentralized_data">Ładowanie zdecentralizowanych danych...</string>
     <string name="related_content">Powiązana zawartość</string>
     <string name="comments">Komentarze</string>
     <string name="no_comments">Brak komentarzy do wyświetlenia w tej chwili.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Download</string>
     <string name="open">Abrir</string>
     <string name="report">Reportar</string>
-    <string name="loading_decentralized_data">Carregando dados decentralizados...</string>
     <string name="related_content">Conteúdo Relacionado</string>
     <string name="comments">Comentarios</string>
     <string name="no_comments">Não há comentários para exibir no momento.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Download</string>
     <string name="open">Abrir</string>
     <string name="report">Reportar</string>
-    <string name="loading_decentralized_data">Carregando dados descentralizados...</string>
     <string name="related_content">Conteúdo relacionado</string>
     <string name="comments">Comentários</string>
     <string name="no_comments">Sem comentários até agora</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Загрузить</string>
     <string name="open">Открыть</string>
     <string name="report">Пожаловаться</string>
-    <string name="loading_decentralized_data">Загружаем децентрализованные данные...</string>
     <string name="related_content">Похожие материалы</string>
     <string name="comments">Комментарии</string>
     <string name="no_comments">Нет комментариев для отображения.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">Preuzmi</string>
     <string name="open">Otvori</string>
     <string name="report">Prijavi</string>
-    <string name="loading_decentralized_data">Učitavam decentralizovane podatke...</string>
     <string name="related_content">Sličan Sadržaj</string>
     <string name="comments">Komentari</string>
     <string name="no_comments">Trenutno nema komentara.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -57,7 +57,6 @@
     <string name="download">下載</string>
     <string name="open">開啟</string>
     <string name="report">回報</string>
-    <string name="loading_decentralized_data">正在載入去中心化數據……</string>
     <string name="related_content">相關內容</string>
     <string name="comments">留言</string>
     <string name="no_comments">目前沒有可顯示的留言。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
     <string name="download">Download</string>
     <string name="open">Open</string>
     <string name="report">Report</string>
-    <string name="loading_decentralized_data">Loading content…</string>
+    <string name="loading_content">Loading content…</string>
     <string name="related_content">Related Content</string>
     <string name="comments">Comments</string>
     <string name="no_comments">No comments to display at this time.</string>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1 

## What is the current behavior?
When a new claim is being loaded, a string is displayed which reads "Loading decentralized data"
## What is the new behavior?
The string is no longer shown