### PR TITLE
Remove USD references on UI

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -3225,7 +3225,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 Lbryio.updateRewardsLists(rewards);
 
                 if (Lbryio.totalUnclaimedRewardAmount > 0) {
-                    updateRewardsUsdVale();
+                    updateRewardsUsdValue();
                 }
             }
 
@@ -3236,7 +3236,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
-    public void updateRewardsUsdVale() {
+    public void updateRewardsUsdValue() {
         if (Lbryio.totalUnclaimedRewardAmount > 0) {
             double usdRewardAmount = Lbryio.totalUnclaimedRewardAmount * Lbryio.LBCUSDRate;
         }

--- a/app/src/main/java/com/odysee/app/model/Claim.java
+++ b/app/src/main/java/com/odysee/app/model/Claim.java
@@ -124,6 +124,11 @@ public class Claim {
         return fee == null || Helper.parseDouble(fee.getAmount(), 0) == 0;
     }
 
+    /**
+     * Calculates price of claim in LBC once it is converted from USD
+     * @param usdRate LBC/USD rate
+     * @return
+     */
     public BigDecimal getActualCost(double usdRate) {
         if (!(value instanceof StreamMetadata)) {
             return new BigDecimal(0);

--- a/app/src/main/res/layout/card_wallet_balance.xml
+++ b/app/src/main/res/layout/card_wallet_balance.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:lbry="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:elevation="4dp">
     <LinearLayout
         android:orientation="vertical"
@@ -29,7 +29,9 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter"
                 android:textSize="16sp"
-                android:textFontWeight="300" />
+                android:textFontWeight="300"
+                android:visibility="gone"
+                tools:visibility="visible"/>
 
             <TextView
                 android:id="@+id/total_balance_desc"
@@ -40,17 +42,10 @@
                 android:textFontWeight="300"
                 android:textSize="@dimen/wallet_detail_balance_desc_font_size" />
 
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="0.5dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginBottom="16dp"
-                android:background="@color/lightDivider" />
-
-
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
                 android:orientation="horizontal">
                 <com.odysee.app.views.CreditsBalanceView
                     android:id="@+id/wallet_spendable_balance"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Refactoring (no functional changes)
- [x] Documentation changes

## Fixes

Issue Number: #1

## What is the current behavior?
Conversion from Credits to USD is displayed on some parts of the UI
## What is the new behavior?
Conversion to USD is no longer displayed
## Other information
This PR keeps code to retrieve the LBC/USD rate, as it could still be used, for example to convert the claim cost from USD to LBC -the dynamic pricing style-.

This PR is also removing a View which was acting as a separator. a layout marginTop attribute is used instead. This simplifies the layout processing.