### PR TITLE
Show correct reaction amount when user has reacted to the content

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2064,8 +2064,10 @@ public class FileViewFragment extends BaseFragment implements
             activity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    likeReactionAmount.setText(String.valueOf(reactions.getOthersLikes()));
-                    dislikeReactionAmount.setText(String.valueOf(reactions.getOthersDislikes()));
+                    int likes = reactions.isLiked() ? reactions.getOthersLikes() + 1 : reactions.getOthersLikes();
+                    int dislikes = reactions.isDisliked() ? reactions.getOthersDislikes() + 1 : reactions.getOthersDislikes();
+                    likeReactionAmount.setText(String.valueOf(likes));
+                    dislikeReactionAmount.setText(String.valueOf(dislikes));
 
                     int inactiveColor = 0;
                     int fireActive = 0;


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1

## What is the current behavior?
After reaction to any content, reaction icon changes color, but the amount doesn't take into count that user had reacted to it, even after refreshing
## What is the new behavior?
Reaction amount now shows the correct amount