### PR TITLE
Refreshing faster user reaction UI status for content

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -194,8 +194,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import static java.util.stream.Collectors.groupingBy;
-
 public class FileViewFragment extends BaseFragment implements
         MainActivity.BackPressInterceptor,
         DownloadActionListener,
@@ -839,6 +837,10 @@ public class FileViewFragment extends BaseFragment implements
 
         // Tasks on the scheduled executor needs to be really terminated to avoid
         // crashes if user presses back after going to a related content from here
+        purgeLoadingReactionsTask();
+    }
+
+    private void purgeLoadingReactionsTask() {
         if (scheduledExecutor != null && !scheduledExecutor.isShutdown() && futureReactions != null) {
             try {
                 // .cancel() will not remove the task, so it is needed to .purge()
@@ -3788,6 +3790,8 @@ public class FileViewFragment extends BaseFragment implements
 
     private void react(Claim claim, boolean like) {
         Runnable runnable = () -> {
+            purgeLoadingReactionsTask();
+
             Map<String, String> options = new HashMap<>();
             options.put("claim_ids", claim.getClaimId());
             options.put("type", like ? "like" : "dislike");
@@ -3797,9 +3801,17 @@ public class FileViewFragment extends BaseFragment implements
                 options.put("remove", "true");
 
             try {
-                Lbryio.call("reaction", "react", options, Helper.METHOD_POST, getContext());
-            } catch (LbryioRequestException | LbryioResponseException e) {
+                JSONObject jsonResponse = (JSONObject) Lbryio.parseResponse(Lbryio.call("reaction", "react", options, Helper.METHOD_POST, getContext()));
+
+                if (jsonResponse != null && jsonResponse.has(claim.getClaimId())) {
+                    reactions.setLiked(jsonResponse.getJSONObject(claim.getClaimId()).has("like") && !reactions.isLiked());
+                    reactions.setDisliked(jsonResponse.getJSONObject(claim.getClaimId()).has("dislike") && !reactions.isDisliked());
+                    updateContentReactions();
+                }
+            } catch (LbryioRequestException | LbryioResponseException | JSONException e) {
                 e.printStackTrace();
+            } finally {
+                loadReactions(claim);
             }
         };
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1

## What is the current behavior?
User reaction status to content is not updated until the scheduler is executed
## What is the new behavior?
Reactions amount is updated accordingly on the UI

## Other information
After a successful API call to react, the code to refresh the UI is called with an updated object. After that, the regular scheduled task is again created. This way, app refreshes the UI status before getting the remote data, but using the reaction request response as the reason to update the status. This makes it feel faster, as the UI is refreshed immediately without having to make a new request.