### PR TITLE
Indent repost info section away from screen edge

### DIFF
--- a/app/src/main/res/layout-sw360dp/list_item_stream.xml
+++ b/app/src/main/res/layout-sw360dp/list_item_stream.xml
@@ -12,6 +12,7 @@
         android:id="@+id/claim_repost_info"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
         android:layout_marginBottom="4dp"
         android:orientation="horizontal"
         android:visibility="gone"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Other - Please describe: UI improvement

## What is the current behavior?
"Reposted by" label sticks to the edge
## What is the new behavior?
The label is indented a little bit