### PR TITLE
Related content no longer replaces current content

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -483,6 +483,8 @@ public class FileViewFragment extends BaseFragment implements
                 resetFee();
                 checkNewClaimAndUrl(newClaim, newUrl);
 
+                claim = null;
+
                 if (newClaim != null) {
                     claim = newClaim;
                 }
@@ -2613,8 +2615,7 @@ public class FileViewFragment extends BaseFragment implements
                                         if (claim.getName().startsWith("@")) {
                                             activity.openChannelClaim(claim);
                                         } else {
-                                            Map<String, Object> params = new HashMap<>();
-                                            params.put("claimId", claim.getClaimId());
+                                            Map<String, Object> params = new HashMap<>(1);
                                             params.put("url", !Helper.isNullOrEmpty(claim.getShortUrl()) ? claim.getShortUrl() : claim.getPermanentUrl());
 
                                             setParams(params);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Clicking on a related content item just reloads currently being played content
## What is the new behavior?
Related content now replaces the content which is currently being played