### PR TITLE
Close ResponseBody to avoid leaks

### DIFF
--- a/app/src/main/java/com/odysee/app/supplier/ReactToCommentSupplier.java
+++ b/app/src/main/java/com/odysee/app/supplier/ReactToCommentSupplier.java
@@ -46,13 +46,14 @@ public class ReactToCommentSupplier implements Supplier<Boolean> {
         }
 
         JSONObject data = null;
+        okhttp3.Response response = null;
         try {
             if (am.getAccounts().length > 0) {
-                okhttp3.Response response = Comments.performRequest(options, "reaction.React");
+                response = Comments.performRequest(options, "reaction.React");
 
                 ResponseBody responseBody = response.body();
 
-                if (responseBody!= null) {
+                if (responseBody != null) {
                     JSONObject jsonResponse = new JSONObject(responseBody.string());
 
                     if (jsonResponse.has("result")) {
@@ -65,6 +66,10 @@ public class ReactToCommentSupplier implements Supplier<Boolean> {
             }
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            if (response != null) {
+                response.close();
+            }
         }
         return data != null && !data.has("error");
     }

--- a/app/src/main/java/com/odysee/app/tasks/BufferEventTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/BufferEventTask.java
@@ -57,8 +57,9 @@ public class BufferEventTask extends AsyncTask<Void, Void, Void> {
             ResponseBody resBody = response.body();
             String responseString = "";
             if (resBody != null) {
-                responseString = response.body().string();
+                responseString = resBody.string();
             }
+            response.close();
             Log.d(TAG, String.format("buffer event sent: %s", responseString));
         } catch (Exception ex) {
             // we don't want to fail if a buffer event fails to register


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
ResponseBody could leak
## What is the new behavior?
ResponseBody is closed after getting the needed data from it. According to documentation, calling Response.body().string() would close it, but this ensures it will be certainly be closed