### PR TITLE
Show channel pictures and claim thumbnails on notifications

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/NotificationListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/NotificationListAdapter.java
@@ -1,6 +1,7 @@
 package com.odysee.app.adapter;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.text.format.DateUtils;
 import android.view.LayoutInflater;
@@ -65,7 +66,8 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
         protected final TextView bodyView;
         protected final TextView timeView;
         protected final SolidIconView iconView;
-        protected final ImageView thumbnailView;
+        protected final ImageView authorThumbnailView;
+        protected final ImageView claimThumbnailView;
         protected final View selectedOverlayView;
         public ViewHolder(View v) {
             super(v);
@@ -74,7 +76,8 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
             bodyView = v.findViewById(R.id.notification_body);
             timeView = v.findViewById(R.id.notification_time);
             iconView = v.findViewById(R.id.notification_icon);
-            thumbnailView = v.findViewById(R.id.notification_author_thumbnail);
+            authorThumbnailView = v.findViewById(R.id.notification_author_thumbnail);
+            claimThumbnailView = v.findViewById(R.id.notification_claim_thumbnail);
             selectedOverlayView = v.findViewById(R.id.notification_selected_overlay);
         }
     }
@@ -128,8 +131,8 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
     public List<String> getAuthorUrls() {
         List<String> urls = new ArrayList<>();
         for (LbryNotification item : items) {
-            if (!Helper.isNullOrEmpty(item.getAuthorUrl())) {
-                urls.add(item.getAuthorUrl());
+            if (!Helper.isNullOrEmpty(item.getAuthorThumbnailUrl())) {
+                urls.add(item.getAuthorThumbnailUrl());
             }
         }
         return urls;
@@ -146,7 +149,7 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
 
     private void updateClaimForAuthorUrl(Claim claim) {
         for (LbryNotification item : items) {
-            if (claim.getPermanentUrl().equalsIgnoreCase(item.getAuthorUrl())) {
+            if (claim.getPermanentUrl().equalsIgnoreCase(item.getAuthorThumbnailUrl())) {
                 item.setCommentAuthor(claim);
             }
         }
@@ -201,13 +204,38 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
         vh.timeView.setText(DateUtils.getRelativeTimeSpanString(
                 getLocalNotificationTime(notification), System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
 
-        vh.thumbnailView.setVisibility(notification.getCommentAuthor() == null ? View.INVISIBLE : View.VISIBLE);
-        if (notification.getCommentAuthor() != null) {
-            Glide.with(context.getApplicationContext()).load(
-                    notification.getCommentAuthor().getThumbnailUrl(vh.thumbnailView.getLayoutParams().width, vh.thumbnailView.getLayoutParams().height, 85)).apply(RequestOptions.circleCropTransform()).into(vh.thumbnailView);
+        vh.authorThumbnailView.setVisibility(notification.getCommentAuthor() == null || notification.getAuthorThumbnailUrl() == null ? View.INVISIBLE : View.VISIBLE);
+        if (notification.getAuthorThumbnailUrl() != null)
+            vh.authorThumbnailView.setVisibility(View.VISIBLE);
+        if (notification.getCommentAuthor() != null || notification.getAuthorThumbnailUrl() != null) {
+            String turl;
+
+            if (notification.getCommentAuthor() != null)
+                turl = notification.getCommentAuthor().getThumbnailUrl(vh.authorThumbnailView.getLayoutParams().width, vh.authorThumbnailView.getLayoutParams().height, 85);
+            else {
+                turl = getThumbnailUrl(vh.authorThumbnailView, notification.getAuthorThumbnailUrl());
+            }
+
+            Glide.with(context.getApplicationContext()).load(turl).apply(RequestOptions.circleCropTransform()).into(vh.authorThumbnailView);
         }
 
-        vh.iconView.setVisibility(notification.getCommentAuthor() != null ? View.INVISIBLE : View.VISIBLE);
+        if (notification.getClaimThumbnailUrl() != null) {
+            vh.bodyView.getLayoutParams().width = (int) (200 * context.getApplicationContext().getResources().getDisplayMetrics().density);
+            Configuration config = context.getApplicationContext().getResources().getConfiguration();
+            if (config.smallestScreenWidthDp > 359) {
+                String turl = getThumbnailUrl(vh.claimThumbnailView, notification.getClaimThumbnailUrl());
+
+                Glide.with(context.getApplicationContext()).asBitmap().load(turl).into(vh.claimThumbnailView);
+                vh.claimThumbnailView.setVisibility(View.VISIBLE);
+            } else {
+                vh.claimThumbnailView.setVisibility(View.GONE);
+            }
+        } else {
+            vh.bodyView.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+            vh.claimThumbnailView.setVisibility(View.GONE);
+        }
+
+        vh.iconView.setVisibility(notification.getCommentAuthor() != null || notification.getAuthorThumbnailUrl() != null ? View.INVISIBLE : View.VISIBLE);
         vh.iconView.setText(getStringIdForRule(notification.getRule()));
         vh.iconView.setTextColor(getColorForRule(notification.getRule()));
 
@@ -236,6 +264,17 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
                 return true;
             }
         });
+    }
+
+    private String getThumbnailUrl(View v, String url) {
+        String appendedPath;
+
+        appendedPath = "s:".concat(String.valueOf(v.getLayoutParams().width))
+                .concat(":").concat(String.valueOf(v.getLayoutParams().height)).concat("/")
+                .concat("quality:").concat(String.valueOf(85)).concat("/")
+                .concat("plain/").concat(url);
+
+        return "https://image-processor.vanwanet.com/optimize/".concat(appendedPath);
     }
 
     private void toggleSelectedNotification(LbryNotification notification) {

--- a/app/src/main/java/com/odysee/app/model/lbryinc/LbryNotification.java
+++ b/app/src/main/java/com/odysee/app/model/lbryinc/LbryNotification.java
@@ -15,7 +15,8 @@ public class LbryNotification implements Comparator<LbryNotification> {
     private long remoteId;
     private String title;
     private String description;
-    private String thumbnailUrl;
+    private String claimThumbnailUrl;
+    private String authorThumbnailUrl;
     private String rule;
     private String targetUrl;
     private boolean read;
@@ -23,7 +24,6 @@ public class LbryNotification implements Comparator<LbryNotification> {
     private Date timestamp;
 
     // only for comment notifications
-    private String authorUrl;
     private Claim commentAuthor;
 
     public int compare(LbryNotification a, LbryNotification b) {

--- a/app/src/main/java/com/odysee/app/tasks/lbryinc/NotificationListTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/lbryinc/NotificationListTask.java
@@ -63,13 +63,24 @@ public class NotificationListTask extends AsyncTask<Void, Void, List<LbryNotific
                         }
                         if (notificationParams.has("dynamic") && !notificationParams.isNull("dynamic")) {
                             JSONObject dynamic = notificationParams.getJSONObject("dynamic");
-                            if (dynamic.has("comment_author")) {
-                                notification.setAuthorUrl(Helper.getJSONString("comment_author", null, dynamic));
+                            if (dynamic.has("comment_author") || dynamic.has("channel_thumbnail")) {
+                                String url = null;
+                                if (dynamic.has("comment_author"))
+                                    url = Helper.getJSONString("comment_author", null, dynamic);
+                                else if (dynamic.has("channel_thumbnail"))
+                                    url = Helper.getJSONString("channel_thumbnail", null, dynamic);
+                                notification.setAuthorThumbnailUrl(url);
                             }
                             if (dynamic.has("channelURI")) {
                                 String channelUrl = Helper.getJSONString("channelURI", null, dynamic);
                                 if (!Helper.isNullOrEmpty(channelUrl)) {
                                     notification.setTargetUrl(channelUrl);
+                                }
+                            }
+                            if (dynamic.has("claim_thumbnail")) {
+                                String claimThumbnailUrl = Helper.getJSONString("claim_thumbnail", null, dynamic);
+                                if (!Helper.isNullOrEmpty(claimThumbnailUrl)) {
+                                    notification.setClaimThumbnailUrl(claimThumbnailUrl);
                                 }
                             }
                             if (dynamic.has("hash") && "comment".equalsIgnoreCase(Helper.getJSONString("notification_rule", null, item))) {

--- a/app/src/main/res/layout/list_item_notification.xml
+++ b/app/src/main/res/layout/list_item_notification.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:background="?attr/selectableItemBackground"
     android:clickable="true"
     android:layout_width="match_parent"
@@ -16,29 +16,29 @@
         android:orientation="horizontal">
         <RelativeLayout
             android:layout_marginStart="16dp"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:layout_gravity="center_vertical">
             <com.odysee.app.ui.controls.SolidIconView
                 android:id="@+id/notification_icon"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
                 android:textSize="24dp" />
             <ImageView
                 android:id="@+id/notification_author_thumbnail"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
                 android:visibility="invisible" />
             <RelativeLayout
                 android:layout_centerHorizontal="true"
                 android:background="@drawable/bg_channel_overlay_icon"
                 android:id="@+id/notification_selected_overlay"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
                 android:visibility="gone">
                 <ImageView
-                    android:layout_width="36dp"
-                    android:layout_height="36dp"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
                     android:layout_centerInParent="true"
                     android:src="@drawable/ic_check"
                     app:tint="@color/nextLbryGreen" />
@@ -56,20 +56,39 @@
                 android:layout_marginBottom="2dp"
                 android:fontFamily="@font/inter"
                 android:textStyle="bold"
-                android:textSize="13sp" />
-            <TextView
-                android:id="@+id/notification_body"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                android:fontFamily="@font/inter"
-                android:textSize="14sp" />
-            <TextView
-                android:id="@+id/notification_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/inter"
-                android:textSize="11sp" />
+                android:textSize="13sp"
+                tools:text="Notification title"/>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView android:id="@+id/notification_body"
+                    android:layout_width="200dp"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/inter"
+                    android:textSize="14sp"
+                    android:layout_marginEnd="8dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="Description for content of the notification" />
+
+                <TextView android:id="@+id/notification_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/inter"
+                    android:textSize="11sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/notification_body"
+                    tools:text="1 hour ago" />
+
+                <ImageView android:id="@+id/notification_claim_thumbnail"
+                    android:layout_width="100dp"
+                    android:layout_height="63dp"
+                    android:visibility="visible"
+                    app:layout_constraintStart_toEndOf="@+id/notification_body"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </LinearLayout>
     </LinearLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #1 

## What is the current behavior?
Channel picture -thumbnail- and content thumbnail are not shown on notification items
## What is the new behavior?
Channel picture is always shown for every notification item. When API responds with a thumbnail URL for the content, then that thumbnail is also shown
## Other information
Database version has been updated.It has been tested that the update process is executed correctly.

About that update: a field has been renamed as it was semantically wrong -it was about the URL for the thumbnail, not the URL for the channel itself-; that requires to recreate the database, as a RENAME method for fields is not yet available for SQLite on Android.

The update renames current table to a temporary one, recreates the new table again, copies old values to the new table, indexes these records and then deletes the temporary table.