### PR TITLE
Store subscriptions filter visibility state as a preference

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -2877,7 +2877,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         Lbryio.currentUser = null;
         Lbryio.AUTH_TOKEN = "";
         SharedPreferences sharedPref = getSharedPreferences("lbry_shared_preferences", Context.MODE_PRIVATE);
-        sharedPref.edit().remove("auth_token").commit();
+        sharedPref.edit().remove("auth_token").apply();
+        sharedPref.edit().remove("subscriptions_filter_visibility").apply();
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
         sp.edit().remove(MainActivity.PREFERENCE_KEY_AUTH_TOKEN).apply();
 

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -212,6 +212,11 @@ public class FollowingFragment extends BaseFragment implements
             }
         });
 
+        if (context != null) {
+            SharedPreferences sharedpreferences = context.getSharedPreferences("lbry_shared_preferences", Context.MODE_PRIVATE);
+            Helper.setViewVisibility(horizontalChannelList, sharedpreferences.getBoolean("subscriptions_filter_visibility", false) ? View.VISIBLE : View.GONE);
+        }
+
         filterLink.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -378,8 +383,14 @@ public class FollowingFragment extends BaseFragment implements
         Context context = getContext();
         if (context instanceof MainActivity) {
             ((MainActivity) context).removeDownloadActionListener(this);
+            PreferenceManager.getDefaultSharedPreferences(context).unregisterOnSharedPreferenceChangeListener(this);
+
+            // Store current state of the channel filter as a preference
+            SharedPreferences sharedpreferences = context.getSharedPreferences("lbry_shared_preferences", Context.MODE_PRIVATE);
+            SharedPreferences.Editor editor = sharedpreferences.edit();
+            editor.putBoolean("subscriptions_filter_visibility", horizontalChannelList.getVisibility() == View.VISIBLE);
+            editor.apply();
         }
-        PreferenceManager.getDefaultSharedPreferences(context).unregisterOnSharedPreferenceChangeListener(this);
         super.onPause();
     }
     public void fetchLoadedSubscriptions(boolean showSubscribed) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?
Every time Following fragment is recreated, default -hidden- state Is used for the subscriptions list visibility
## What is the new behavior?
The state is stored and used when fragment is recreated, even when app was shutdown