### PR TITLE
Clear all database tables when user has signed out

### DIFF
--- a/app/src/main/java/com/odysee/app/data/DatabaseHelper.java
+++ b/app/src/main/java/com/odysee/app/data/DatabaseHelper.java
@@ -239,6 +239,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     public static void clearUrlHistoryBefore(Date date, SQLiteDatabase db) {
         db.execSQL(SQL_CLEAR_URL_HISTORY_BEFORE_TIME, new Object[] { new SimpleDateFormat(Helper.ISO_DATE_FORMAT_PATTERN).format(new Date()) });
     }
+    public static void clearViewHistory(SQLiteDatabase db) {
+        db.execSQL(SQL_CLEAR_VIEW_HISTORY);
+    }
 
     // History items are essentially url suggestions
     public static List<UrlSuggestion> getRecentHistory(SQLiteDatabase db) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1

## What is the current behavior?
When user has signed out or its account has been removed, database tables are not cleared
## What is the new behavior?
All data is cleared when app sees that Odysee account has been removed from the device.
## Other information
This is also fixing a problem which caused getting a blanck fragment when browsing to any fragment after swipping on the notification list and then closing it