### PR TITLE
Show launcher drawable instead of blank background when cold starting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:supportsPictureInPicture="true"
-            android:theme="@style/AppTheme.NoActionBar"
+            android:theme="@style/SplashTheme"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -411,8 +411,33 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     private static final int STARTUP_STAGE_FILTER_LIST_LOADED = 9;
     private static final int DEFAULT_MINI_PLAYER_MARGIN = 4;
 
+    private boolean readyToDraw = false;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        setTheme(R.style.AppTheme_NoActionBar);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        if (Build.VERSION.SDK_INT < 31) {
+            findViewById(R.id.root).setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+            findViewById(R.id.launch_splash).setVisibility(View.VISIBLE);
+        } else {
+            findViewById(R.id.root).getViewTreeObserver().addOnPreDrawListener(
+                new ViewTreeObserver.OnPreDrawListener() {
+                    @Override
+                    public boolean onPreDraw() {
+                        // Check if the initial data is ready.
+                        if (readyToDraw) {
+                            // The content is ready; start drawing.
+                            findViewById(R.id.root).getViewTreeObserver().removeOnPreDrawListener(this);
+                            return true;
+                        } else {
+                            // The content is not ready; suspend.
+                            return false;
+                        }
+                    }
+                });
+        }
         instance = this;
         // workaround to fix dark theme because https://issuetracker.google.com/issues/37124582
         try {
@@ -445,13 +470,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             // pass
         }
 
-        super.onCreate(savedInstanceState);
         dbHelper = new DatabaseHelper(this);
         checkNotificationOpenIntent(getIntent());
-        setContentView(R.layout.activity_main);
-
-        findViewById(R.id.root).setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-        findViewById(R.id.launch_splash).setVisibility(View.VISIBLE);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -2196,30 +2216,34 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     private void hideLaunchScreen() {
-        // Animate?
-        View launchSplash = findViewById(R.id.launch_splash);
-        if (launchSplash.getVisibility() == View.VISIBLE) {
-            int width = launchSplash.getWidth();
-            ValueAnimator valueAnimator = ValueAnimator.ofInt(width, 0);
-            valueAnimator.setInterpolator(new DecelerateInterpolator());
-            valueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-                @Override
-                public void onAnimationUpdate(ValueAnimator animation) {
-                    launchSplash.getLayoutParams().width = (int) animation.getAnimatedValue();
-                    launchSplash.requestLayout();
-                }
-            });
-            valueAnimator.setInterpolator(new DecelerateInterpolator());
-            valueAnimator.setDuration(200);
-            valueAnimator.addListener(new AnimatorListenerAdapter() {
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    launchSplash.clearAnimation();
-                    launchSplash.setVisibility(View.GONE);
-                    findViewById(R.id.root).setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
-                }
-            });
-            valueAnimator.start();
+        if (Build.VERSION.SDK_INT < 31) {
+            // Animate?
+            View launchSplash = findViewById(R.id.launch_splash);
+            if (launchSplash.getVisibility() == View.VISIBLE) {
+                int width = launchSplash.getWidth();
+                ValueAnimator valueAnimator = ValueAnimator.ofInt(width, 0);
+                valueAnimator.setInterpolator(new DecelerateInterpolator());
+                valueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+                    @Override
+                    public void onAnimationUpdate(ValueAnimator animation) {
+                        launchSplash.getLayoutParams().width = (int) animation.getAnimatedValue();
+                        launchSplash.requestLayout();
+                    }
+                });
+                valueAnimator.setInterpolator(new DecelerateInterpolator());
+                valueAnimator.setDuration(200);
+                valueAnimator.addListener(new AnimatorListenerAdapter() {
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        launchSplash.clearAnimation();
+                        launchSplash.setVisibility(View.GONE);
+                        findViewById(R.id.root).setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+                    }
+                });
+                valueAnimator.start();
+            }
+        } else {
+            readyToDraw = true;
         }
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -127,12 +127,8 @@
         android:focusableInTouchMode="true"
         android:clickable="true"
         android:id="@+id/launch_splash"
+        android:background="@drawable/launch_screen"
         android:visibility="gone">
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="centerCrop"
-            android:src="@drawable/launch_screen" />
         <ProgressBar
             android:layout_width="36dp"
             android:layout_height="36dp"

--- a/app/src/main/res/values-v26/styles.xml
+++ b/app/src/main/res/values-v26/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="SplashTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowSplashscreenContent">@drawable/launch_screen</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="SplashTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowBackground">@drawable/launch_screen</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,10 @@
         <item name="android:textColor">?android:attr/textColorPrimary</item>
     </style>
 
+    <style name="SplashTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowBackground">@drawable/launch_screen</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## What is the current behavior?
When app starts, Android shows a white-ish or black-ish background as a preview to look like it is instantly starting, while in fact it is still creating the process and doing lots of other stuff before being able to draw. Then the app shows, in this case, the "splash screen"
## What is the new behavior?
Theme has been changed so it is showing the same background used by the "splash screen" and then it automatically .without any gap- transitions into the "splash screen".

On Android 12, there is no way to disable how Android shows the splash screen, which consists of a coloured background -taken from windowBackground- with app icon on top. My solution has been to not show our "splash screen" to avoid showing two of them to the user. Android generated splash screen is shown for the same amount of time as the one we would show. This is done by listening to preDraw events.

## More information
The "splash screen" has been changed -the ImageView removed- to avoid a glitch which caused the image to be stretched when it is shown. This way the layout is simpler and it has the same effect as previously.

This PR doesn't need to call new APIs only available on Android 12, so I made no changes to build.gradle and use '31' instead of VERSION_CODES.S. I tested this on an emulator running Android 12 and it works as expected for that API Level.
