### PR TITLE
Use thumbnails.odysee.com for thumbnails graphic files

### DIFF
--- a/app/src/main/java/com/odysee/app/model/Claim.java
+++ b/app/src/main/java/com/odysee/app/model/Claim.java
@@ -569,7 +569,7 @@ public class Claim {
 
         @Override
         public String toString() {
-            String url = "https://image-processor.vanwanet.com/optimize/";
+            String url = "https://thumbnails.odysee.com/optimize/";
             return url.concat(appendedPath);
         }
     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Thumbnails are no longer loading from vanwanet.com
## What is the new behavior?
thumbnails.odysee.com should be used instead
## Other information
This is a one line change and it is also not making any functional change to the code, just pointing to a different server on the Internet, so I am no making any review request