### PR TITLE
Change visibility for views on the main thread

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -831,7 +831,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             public void onRefresh() {
                 notificationsSwipeContainer.setRefreshing(true);
                 loadRemoteNotifications(false);
-                // FIXME This is causing blank fragments after closing notification's list and opening a different bottom tab
             }
         });
 
@@ -3929,8 +3928,15 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     private void loadLocalNotifications() {
-        findViewById(R.id.notification_list_empty_container).setVisibility(View.GONE);
-        findViewById(R.id.notifications_progress).setVisibility(View.VISIBLE);
+        // Path to here could from from not the main thread, so let's ensure changing visibility
+        // is requested from the main thread
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                findViewById(R.id.notification_list_empty_container).setVisibility(View.GONE);
+                findViewById(R.id.notifications_progress).setVisibility(View.VISIBLE);
+            }
+        });
 
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
             Supplier<List<LbryNotification>> task = new GetLocalNotificationsSupplier();


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Visibility is changed from the calling method thread. This thread is sometimes not the main thread, causing rendering issues after swiping on the Notifications fragment, i.e. new fragments being rendered blank.

When user wasn't logged in, the notifications empty list view was no longer shown after swiping to request new notifications.
## What is the new behavior?
Now visibility change is made explicitly from the main thread