### PR TITLE
Remove auth_token from shared preferences

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -573,6 +573,13 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             sharedPreferencesEditor.commit();
         }
 
+        // Preliminary internal releases of Odysee was using SharedPreferences to store the authentication token.
+        // Currently, it is using Android AccountManager, so let's check if value is stored and remove it for
+        // for privacy concerns.
+        if (sharedPreferences.contains("auth_token")) {
+            sharedPreferencesEditor.remove("auth_token").apply();
+        }
+
         // Create Fragment instances here so they are not recreated when selected on the bottom navigation bar
         Fragment homeFragment = new AllContentFragment();
         Fragment followingFragment = new FollowingFragment();
@@ -742,10 +749,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     buttonShowRewards.setVisibility(View.VISIBLE);
                     signUserButton.setVisibility(View.GONE);
                     userIdText.setText(am.getUserData(odyseeAccount, "email"));
-                    SharedPreferences sharedPref = getSharedPreferences("lbry_shared_preferences", Context.MODE_PRIVATE);
-                    SharedPreferences.Editor editor = sharedPref.edit();
-                    editor.putString("auth_token", Lbryio.AUTH_TOKEN);
-                    editor.apply();
                 } else {
                     userIdText.setVisibility(View.GONE);
                     userIdText.setText("");


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## What is the current behavior?
Authentication token is stored as a shared preference. This was used on the pre-alpha stage before switching to AccountManager API. This shared preference is not used anywhere else.
## What is the new behavior?
The authentication token is no longer stored as a shared preference.

Shared preference would still be stored after app is updated, so this PR is also removing it if found.