### PR TITLE
Remove authentication token from default shared preferences

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -576,6 +576,12 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             sharedPreferencesEditor.remove("auth_token").apply();
         }
 
+        SharedPreferences defaultSharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        SharedPreferences.Editor defaultSharedPreferencesEditor = defaultSharedPreferences.edit();
+        if (defaultSharedPreferences.contains("com.odysee.app.Preference.AuthToken")) {
+            defaultSharedPreferencesEditor.remove("com.odysee.app.Preference.AuthToken").apply();
+        }
+
         // Create Fragment instances here so they are not recreated when selected on the bottom navigation bar
         Fragment homeFragment = new AllContentFragment();
         Fragment followingFragment = new FollowingFragment();

--- a/app/src/main/java/com/odysee/app/utils/Lbryio.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbryio.java
@@ -4,14 +4,11 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
-
-import androidx.preference.PreferenceManager;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -26,7 +23,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -267,12 +263,6 @@ public final class Lbryio {
                 if (error.getStatusCode() == 403) {
                     // auth token invalidated
                     AUTH_TOKEN = null;
-                    // remove the cached auth token
-                    if (context != null) {
-                        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
-                        sp.edit().remove(MainActivity.PREFERENCE_KEY_AUTH_TOKEN).apply();
-                    }
-
                     throw new AuthTokenInvalidatedException();
                 }
             }


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## What is the current behavior?
Authentication token is stored on default shared preferences file
## What is the new behavior?
Token is no longer stored on shared preferences