### PR TITLE
Remove notification as source param when navigating to channel

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -1288,6 +1288,8 @@ public class FileViewFragment extends BaseFragment implements
             @Override
             public void onClick(View view) {
                 if (claim != null && claim.getSigningChannel() != null) {
+                    removeNotificationAsSource();
+
                     Claim publisher = claim.getSigningChannel();
                     Context context = getContext();
                     if (context instanceof  MainActivity) {
@@ -1344,6 +1346,23 @@ public class FileViewFragment extends BaseFragment implements
         LinearLayoutManager commentsListLLM = new LinearLayoutManager(getContext());
         relatedContentList.setLayoutManager(relatedContentListLLM);
         commentsList.setLayoutManager(commentsListLLM);
+    }
+
+    private void removeNotificationAsSource() {
+        // If we arrived here from a notification, navigating to a channel
+        // will show the notifications panel and a very weird layout after
+        // it.
+        // So let's avoid it by removing that flag. User will need to re-open
+        // the panel again to keep visiting content from notifications
+        Map<String, Object> params = getParams();
+        if (params != null && params.containsKey("source")) {
+            String notificationSource = (String) params.get("source");
+
+            if ("notification".equalsIgnoreCase(notificationSource)) {
+                params.remove("source");
+                setParams(params);
+            }
+        }
     }
 
     private void updatePlaybackSpeedView(View root) {
@@ -2831,9 +2850,9 @@ public class FileViewFragment extends BaseFragment implements
                         commentListAdapter.setListener(new ClaimListAdapter.ClaimListItemListener() {
                             @Override
                             public void onClaimClicked(Claim claim) {
-                                if (!Helper.isNullOrEmpty(claim.getName()) &&
-                                        claim.getName().startsWith("@") &&
+                                if (!Helper.isNullOrEmpty(claim.getName()) && claim.getName().startsWith("@") &&
                                         ctx instanceof MainActivity) {
+                                    removeNotificationAsSource();
                                     ((MainActivity) ctx).openChannelClaim(claim);
                                 }
                             }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
1. User clicks on a new content notification
2. Content is displayed
3. User clicks on a channel
4. Notification panel is shown without the AppBar
5. If user now clicks back, a weird layout appears showing the Home screen on the bottom half
## What is the new behavior?
Points 4 and 5 no longer happens and expected content is shown