### PR TITLE
Stop player to avoid glitches after returning to app from PiP

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -895,6 +895,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         accountManager = AccountManager.get(this);
     }
 
+    /**
+     * Call this method when starting a new activity to avoid display glitches when user re-opens app from picture-in-picture
+     */
     private void clearPlayingPlayer() {
         if (appPlayer != null && appPlayer.isPlaying()) {
             appPlayer.stop();

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -652,6 +652,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 //                findViewById(R.id.main_activity_other_fragment).setVisibility(View.VISIBLE);
 //                findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);
 //                hideActionBar();
+                clearPlayingPlayer();
                 startActivity(new Intent(view.getContext(), ComingSoon.class));
             }
         });
@@ -892,6 +893,13 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         });
 
         accountManager = AccountManager.get(this);
+    }
+
+    private void clearPlayingPlayer() {
+        if (appPlayer != null && appPlayer.isPlaying()) {
+            appPlayer.stop();
+            clearNowPlayingClaim();
+        }
     }
 
     @Override
@@ -3032,6 +3040,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     public void simpleSignIn(int sourceTabId) {
+        clearPlayingPlayer();
         Intent intent = new Intent(this, SignInActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
         intent.putExtra("sourceTabId", sourceTabId);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
When a new activity is started and user is playing some content, it is switched to picure-in-picture mode. When user then returns to the content by clicking on the PiP window, app screen is totally messed.
## What is the new behavior?
When app opens a new activity -like the Coming Soon or SignIn activities, for example- currently playing claim will be cleared from app state and player will also be stopped
## Other information
After the merging PR for driving user to sign in when it is required, user will need to browse again to the content it was been played; it is better that than showing a bad UI when clicking the PiP window.