### PR TITLE
Show mini-player after back key is pressed

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -1920,11 +1920,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     public void checkNowPlaying() {
-        Fragment fragment = getCurrentFragment();
-        if (fragment instanceof FileViewFragment) {
-            return;
-        }
-
         // Don't show the toolbar when returning from the Share Activity
         if (getSupportFragmentManager().findFragmentByTag("FileView") == null)
             findViewById(R.id.toolbar).setVisibility(View.VISIBLE);
@@ -1933,8 +1928,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             ((TextView) findViewById(R.id.global_now_playing_title)).setText(nowPlayingClaim.getTitle());
             ((TextView) findViewById(R.id.global_now_playing_channel_title)).setText(nowPlayingClaim.getPublisherTitle());
         }
-        if (appPlayer != null) {
-            // TODO This will reset player when changing tabs. See if it is needed
+        if (appPlayer != null && !playerReassigned) {
             PlayerView playerView = findViewById(R.id.global_now_playing_player_view);
             playerView.setPlayer(null);
             playerView.setPlayer(appPlayer);
@@ -3027,9 +3021,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 findViewById(R.id.fragment_container_main_activity).setVisibility(View.VISIBLE);
             } else {
                 moveTaskToBack(true);
+                checkNowPlaying();
             }
-
-            return;
         }
     }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
When user clicks back on its device when consuming any playable claim, mini player is no longer visible. User needs to navigate to any other place, like switching to another tab, for example, in order to see the mini-player.

The player itself is reset every time user navigates to other place on the app.
## What is the new behavior?
Mini-player is now shown as expected and the player is no longer reset when a new fragment is shown.