### PR TITLE
Remove lbry protocol to lbry.tv url conversion method

### DIFF
--- a/app/src/main/java/com/odysee/app/utils/LbryUri.java
+++ b/app/src/main/java/com/odysee/app/utils/LbryUri.java
@@ -10,7 +10,6 @@ import lombok.Data;
 
 @Data
 public class LbryUri {
-    public static final String LBRY_TV_BASE_URL = "https://lbry.tv/";
     public static final String ODYSEE_COM_BASE_URL = "https://odysee.com/";
     public static final String PROTO_DEFAULT = "lbry://";
     public static final String REGEX_INVALID_URI = "[ =&#:$@%?;/\\\\\"<>%\\{\\}|^~\\[\\]`\u0000-\u0008\u000b-\u000c\u000e-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]";
@@ -249,15 +248,6 @@ public class LbryUri {
 
     public static String normalize(String url) throws LbryUriException {
         return parse(url).toString();
-    }
-
-    /**
-     * @deprecated LBRY.TV will shutdown, so this will be useless. Use toOdyseeString() instead
-     * @return
-     */
-    @Deprecated
-    public String toTvString() {
-        return build(true, LBRY_TV_BASE_URL, false);
     }
 
     public String toOdyseeString() {

--- a/app/src/test/java/com/odysee/app/utils/LbryUriTest.java
+++ b/app/src/test/java/com/odysee/app/utils/LbryUriTest.java
@@ -114,19 +114,6 @@ public class LbryUriTest {
     }
 
     @Test
-    public void lbryToTvString() {
-        LbryUri obtained = new LbryUri();
-
-        try {
-            obtained = LbryUri.parse("lbry://@lbry#3f/lbryturns4#6",false);
-        } catch (LbryUriException e) {
-            e.printStackTrace();
-        }
-
-        assertEquals("https://lbry.tv/@lbry:3f/lbryturns4:6", obtained.toTvString());
-    }
-
-    @Test
     public void lbryToOdyseeString() {
         LbryUri obtained = new LbryUri();
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## What is the current behavior?
LBRY.TV domain is no longer active, so conversion method from lory:// protocol to the domain is no  longer useful.
## What is the new behavior?
Test and method are gone.