### PR TITLE
Upgrade OkHttp to 4.9.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation ("com.github.bumptech.glide:glide:4.11.0") {
         exclude group: "com.android.support"
     }
-    implementation 'com.squareup.okhttp3:okhttp:4.4.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'com.google.firebase:firebase-analytics:19.0.1'
     implementation 'com.google.firebase:firebase-crashlytics:18.2.1'
     implementation 'com.google.android.gms:play-services-base:17.6.0'


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Other - Please describe: Dependency upgrade

## What is the current behavior?
OkHttp was logging an exception about Conscrypt not been available.
## What is the new behavior?
The exception is no longer logged. Also some threading problems are also potentially fixed. And built package size can also be a little bit smaller as some dependencies has been removed on latest OkHttp releases.

See [release notes](https://square.github.io/okhttp/changelog/#version-491). Original OkHttp version used by Odysee Android was 4.4.1.

There are a few newer versions there, but as they are still alpha, I think it is better to still keep using stable ones here.