### PR TITLE
Collections cannot be livestreams

### DIFF
--- a/app/src/main/java/com/odysee/app/utils/Lbry.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbry.java
@@ -493,7 +493,7 @@ public final class Lbry {
 
                     // Livestreams don't have a source set. Then request a livestream URL only for
                     // audio and video, even for reposted claims
-                    if (!claim.hasSource() && claim.getSigningChannel() != null) {
+                    if (!Claim.TYPE_COLLECTION.equalsIgnoreCase(claim.getValueType()) && !claim.hasSource() && claim.getSigningChannel() != null) {
                         String urlLivestream = String.format("https://api.live.odysee.com/v1/odysee/live/%s", claim.getSigningChannel().getClaimId());
 
                         Request.Builder builder = new Request.Builder().url(urlLivestream);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
For every **claim_search** call's returned item, a check for it to be a livestream is made when it has **no_source** set. That's making more network requests and clearly slowing the app because collections -playlists- cannot be a livestream, although they don't have a source set. For claims that don't have a source set, a network request is made to get the URL for the player.
## What is the new behavior?
Now collections are no longer checked to be a livestream.