### PR TITLE
Remove claims with a future release time from Following fragment

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -24,8 +24,11 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
 
@@ -632,6 +635,13 @@ public class FollowingFragment extends BaseFragment implements
             public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
                 claims = Helper.filterClaimsByOutpoint(claims);
                 claims = Helper.filterClaimsByBlockedChannels(claims, Lbryio.blockedChannels);
+
+                Date d = new Date();
+                Calendar cal = new GregorianCalendar();
+                cal.setTime(d);
+
+                // Remove claims with a release time in the future
+                claims.removeIf(e -> ((Claim.StreamMetadata) e.getValue()).getReleaseTime() > (cal.getTimeInMillis() / 1000L));
 
                 // Sort claims so those which are livestreaming now are shwon on the top of the list
                 Collections.sort(claims, new Comparator<Claim>() {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
If "claim_search" request returns claims with a release time in the future -likely a scheduled livestream-, it will still be listed on the Following fragment, while app will be unable to play content, annoying the user.
## What is the new behavior?
Claims with a release time in the future is removed from the list even before any other processing, like sorting by its "live" status.