### PR TITLE
Fix NPE crash when liking a comment that you just made.

### DIFF
--- a/app/src/main/java/com/odysee/app/model/Reactions.java
+++ b/app/src/main/java/com/odysee/app/model/Reactions.java
@@ -23,4 +23,11 @@ public class Reactions {
         this.liked = liked;
         this.disliked = disliked;
     }
+
+    /**
+     * Convenience function for common construction case.
+     */
+    public static Reactions newInstanceWithNoLikesOrDislikes() {
+        return new Reactions(0, 0, false, false);
+    }
 }

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -3866,6 +3866,16 @@ public class FileViewFragment extends BaseFragment implements
             options.put("type", like ? "like" : "dislike");
             options.put("clear_types", like ? "dislike" : "like");
 
+            /**
+             * This covers the case of a fresh comment being made and added to the list, and then liked by
+             * the commenter themself, but the {@link Reactions} field is not instantiated in this case. It
+             * would perhaps be better to fix this upstream and make this situation impossible, but even then
+             * this last line of defense doesn't hurt.
+             */
+            if ( comment.getReactions() == null ) {
+                comment.setReactions(Reactions.newInstanceWithNoLikesOrDislikes());
+            }
+
             if ((like && comment.getReactions().isLiked()) || (!like && comment.getReactions().isDisliked()))
                 options.put("remove", true);
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

This solves the issue `after commenting, own post has 1 fire, if you click fire again, it crashes.` noted in #91.

## What is the current behavior?
App crashes with a NPE when liking a comment that you yourself just made.

## What is the new behavior?
Fixes the crash so the NPE doesn't happen, by adding a null check and instantiation of the null field right before it's accessed.

## Other information

I added a static convenience constructor for the `Reactions` class. If this makes sense then I can replace the other references to the plain constructor. No worries if you'd like to keep the plain constructor paradigm.
