### PR TITLE
Fix crash on Following fragment

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -641,7 +641,10 @@ public class FollowingFragment extends BaseFragment implements
                 cal.setTime(d);
 
                 // Remove claims with a release time in the future
-                claims.removeIf(e -> ((Claim.StreamMetadata) e.getValue()).getReleaseTime() > (cal.getTimeInMillis() / 1000L));
+                claims.removeIf(e -> {
+                    Claim.GenericMetadata metadata = e.getValue();
+                    return metadata instanceof Claim.StreamMetadata && (((Claim.StreamMetadata) metadata).getReleaseTime()) > (cal.getTimeInMillis() / 1000L);
+                });
 
                 // Sort claims so those which are livestreaming now are shwon on the top of the list
                 Collections.sort(claims, new Comparator<Claim>() {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
App is crashing for user when it is logged in and then opens the Following tab
## What is the new behavior?
App no longer crashes