### PR TITLE
Fix related content loading on same fragment reversion

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -446,9 +446,8 @@ public class FileViewFragment extends BaseFragment implements
             if (params != null) {
                 if (params.containsKey("claim")) {
                     newClaim = (Claim) params.get("claim");
-                    if (newClaim != null) {
-                        // the fragment is recreated every time, so just set newClaim
-                        this.claim = newClaim;
+                    // Only update fragment if new claim is different than currently being played
+                    if (newClaim != null && !newClaim.equals(this.claim)) {
                         updateRequired = true;
                     }
                 }
@@ -488,6 +487,9 @@ public class FileViewFragment extends BaseFragment implements
                 resetViewCount();
                 resetFee();
                 checkNewClaimAndUrl(newClaim, newUrl);
+
+                // This is required to recycle current fragment with new claim from related content
+                claim = null;
 
                 if (newClaim != null) {
                     claim = newClaim;
@@ -2672,6 +2674,9 @@ public class FileViewFragment extends BaseFragment implements
                         try {
                             List<Claim> result = future.get();
 
+                            if (executor != null && !executor.isShutdown()) {
+                                executor.shutdown();
+                            }
                             MainActivity a = (MainActivity) getActivity();
 
                             if (a != null) {
@@ -2684,6 +2689,10 @@ public class FileViewFragment extends BaseFragment implements
                                 });
                             }
                         } catch (InterruptedException | ExecutionException e) {
+                            if (executor != null && !executor.isShutdown()) {
+                                executor.shutdown();
+                            }
+
                             e.printStackTrace();
                         }
                     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #131

## What is the current behavior?
Related content no longer loads; resetting currently being played video instead
## What is the new behavior?
Related content is now loading, recycling current fragment.
## Other information
Executor is also shutdown