### PR TITLE
Fix crash on samsung devices when adding new account

### DIFF
--- a/app/src/main/java/com/odysee/app/SignInActivity.java
+++ b/app/src/main/java/com/odysee/app/SignInActivity.java
@@ -684,7 +684,7 @@ public class SignInActivity extends Activity {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        Account act = accountManager.getAccounts()[0];
+        Account act = Helper.getOdyseeAccount(accountManager.getAccounts());
         accountManager.setAuthToken(act, ARG_AUTH_TYPE, Lbryio.AUTH_TOKEN);
     }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
App crashes after adding new account
## What is the new behavior?
App is no longer crashing, account also stores authtentication token