### PR TITLE
Fix crash on Samsung devices when fetching transactions

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/wallet/WalletFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/wallet/WalletFragment.java
@@ -193,7 +193,7 @@ public class WalletFragment extends BaseFragment implements WalletBalanceListene
         AccountManager am = AccountManager.get(getContext());
         Account[] accounts = am.getAccounts();
 
-        TransactionListTask task = new TransactionListTask(1, 5, am.peekAuthToken(accounts[0], "auth_token_type"), loadingRecentContainer, new TransactionListTask.TransactionListHandler() {
+        TransactionListTask task = new TransactionListTask(1, 5, am.peekAuthToken(Helper.getOdyseeAccount(accounts), "auth_token_type"), loadingRecentContainer, new TransactionListTask.TransactionListHandler() {
             @Override
             public void onSuccess(List<Transaction> transactions, boolean hasReachedEnd) {
                 hasFetchedRecentTransactions = true;


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
App will crash when user tries to open Wallet tab on a device made my Samsung
## What is the new behavior?
App is no longer crashing