### PR TITLE
Remove legacy LBRY Android largeHeap attribute

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,6 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:largeHeap="true"
         android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
@@ -136,7 +135,7 @@
         </activity>
         <activity
             android:name=".ComingSoon"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+            android:theme="@style/AppTheme.NoActionBar"/>
         <activity
             android:name=".FirstRunActivity"
             android:launchMode="singleTask"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## What is the current behavior?
App is allowed to have a large memory heap. That was something left from original LBRY Android source code. It was using a daemon which downloaded blockchain headers, which could lead to too much memory to be used.
## What is the new behavior?
Odysee is not using lots of memory so it is safe to remove this attribute.