### PR TITLE
Force splash screen to be portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,7 @@
             android:launchMode="singleTask"
             android:supportsPictureInPicture="true"
             android:theme="@style/SplashTheme"
+            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -20,6 +20,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.database.sqlite.SQLiteDatabase;
@@ -2473,6 +2474,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             // Animate?
             View launchSplash = findViewById(R.id.launch_splash);
             if (launchSplash.getVisibility() == View.VISIBLE) {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
                 int width = launchSplash.getWidth();
                 ValueAnimator valueAnimator = ValueAnimator.ofInt(width, 0);
                 valueAnimator.setInterpolator(new DecelerateInterpolator());


### PR DESCRIPTION
Make orientation unspecified (uses sensor/user setting) after
MainActivity finishes loading.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: No issue created

## What is the current behavior?

App can be rotated to landscape while splash screen is shown, distorting the image.

## What is the new behavior?

Force the app orientation to `portrait` until MainActivity has finished loading.
