### PR TITLE
Fix player not being centered in fullscreen mode

### DIFF
--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -126,7 +126,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@android:color/black"
-                android:fitsSystemWindows="true"
                 android:visibility="gone">
 
                 <com.google.android.exoplayer2.ui.PlayerView


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #118 

## What is the current behavior?

The video player has `fitsSystemWindows` set to true, which causes it to not overlap with the {back,home,apps} buttons and the status bar. However, when the status bar is not shown, the video will appear off center.

## What is the new behavior?

The video player is centered (and will be under the status bar when it is shown, which is expected).
