### PR TITLE
Hide notifications when user goes to any item from the profile menu

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -798,7 +798,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 });
                 MaterialButton signUserButton = customView.findViewById(R.id.button_sign_user);
 
-
                 View buttonChannels = customView.findViewById(R.id.button_channels);
                 View buttonShowRewards = customView.findViewById(R.id.button_show_rewards);
                 View buttonYouTubeSync = customView.findViewById(R.id.button_youtube_sync);
@@ -830,6 +829,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     @Override
                     public void onClick(View view) {
                         popupWindow.dismiss();
+                        hideNotifications();
                         openFragment(SettingsFragment.class, true, null);
                     }
                 });
@@ -838,6 +838,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     @Override
                     public void onClick(View view) {
                         popupWindow.dismiss();
+                        hideNotifications();
 
                         CustomTabColorSchemeParams.Builder ctcspb = new CustomTabColorSchemeParams.Builder();
                         ctcspb.setToolbarColor(ContextCompat.getColor(MainActivity.this, R.color.colorPrimary));
@@ -853,6 +854,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     @Override
                     public void onClick(View view) {
                         popupWindow.dismiss();
+                        hideNotifications();
 
                         CustomTabColorSchemeParams.Builder ctcspb = new CustomTabColorSchemeParams.Builder();
                         ctcspb.setToolbarColor(ContextCompat.getColor(MainActivity.this, R.color.colorPrimary));
@@ -884,6 +886,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     @Override
                     public void onClick(View view) {
                         popupWindow.dismiss();
+                        hideNotifications();
                         startActivity(new Intent(MainActivity.this, YouTubeSyncActivity.class));
                     }
                 });
@@ -892,6 +895,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     public void onClick(View view) {
                         // Close the popup window so its status gets updated when user opens it again
                         popupWindow.dismiss();
+                        hideNotifications();
                         simpleSignIn(R.id.action_home_menu);
                     }
                 });
@@ -900,6 +904,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     @Override
                     public void onClick(View view) {
                         popupWindow.dismiss();
+                        hideNotifications();
                         if (isSignedIn) {
                             signOutUser();
                         }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #91

## What is the current behavior?
Activity layout will be corrupted when user tries to go to any section on the Profile menu while the notification list is being displayed
## What is the new behavior?
Notification list is hidden