### PR TITLE
Implement quality selection for transcoded videos

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,12 +95,12 @@ dependencies {
     implementation 'com.android.billingclient:billing:3.0.2'
 
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.14.2'
-    implementation 'com.google.android.exoplayer:exoplayer-dash:2.14.2'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.14.2'
-    implementation 'com.google.android.exoplayer:extension-cast:2.14.2'
-    implementation 'com.google.android.exoplayer:extension-mediasession:2.14.2'
-    implementation 'com.google.android.exoplayer:exoplayer-hls:2.14.2'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.16.0'
+    implementation 'com.google.android.exoplayer:exoplayer-dash:2.16.0'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.16.0'
+    implementation 'com.google.android.exoplayer:extension-cast:2.16.0'
+    implementation 'com.google.android.exoplayer:extension-mediasession:2.16.0'
+    implementation 'com.google.android.exoplayer:exoplayer-hls:2.16.0'
 
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
 

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -291,6 +291,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public static int nowPlayingSource;
     public static Claim nowPlayingClaim;
     public static String nowPlayingClaimUrl;
+    public static boolean videoIsTranscoded;
+    public static int videoQuality;
     public static boolean startingFilePickerActivity = false;
     public static boolean startingShareActivity = false;
     public static boolean startingPermissionRequest = false;

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -364,6 +364,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public static final String PREFERENCE_KEY_INTERNAL_BACKGROUND_PLAYBACK = "com.odysee.app.preference.userinterface.BackgroundPlayback";
     public static final String PREFERENCE_KEY_INTERNAL_BACKGROUND_PLAYBACK_PIP_MODE = "com.odysee.app.preference.userinterface.BackgroundPlaybackPIPMode";
     public static final String PREFERENCE_KEY_INTERNAL_MEDIA_AUTOPLAY = "com.odysee.app.preference.userinterface.MediaAutoplay";
+    public static final String PREFERENCE_KEY_INTERNAL_WIFI_DEFAULT_QUALITY = "com.odysee.app.preference.userinterface.WifiDefaultQuality";
+    public static final String PREFERENCE_KEY_INTERNAL_MOBILE_DEFAULT_QUALITY = "com.odysee.app.preference.userinterface.MobileDefaultQuality";
     public static final String PREFERENCE_KEY_DARK_MODE = "com.odysee.app.preference.userinterface.DarkMode";
     public static final String PREFERENCE_KEY_SHOW_MATURE_CONTENT = "com.odysee.app.preference.userinterface.ShowMatureContent";
     public static final String PREFERENCE_KEY_SHOW_URL_SUGGESTIONS = "com.odysee.app.preference.userinterface.UrlSuggestions";
@@ -1122,6 +1124,16 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public boolean isMediaAutoplayEnabled() {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
         return sp.getBoolean(PREFERENCE_KEY_INTERNAL_MEDIA_AUTOPLAY, true);
+    }
+
+    public int wifiDefaultQuality() {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+        return Integer.parseInt(sp.getString(PREFERENCE_KEY_INTERNAL_WIFI_DEFAULT_QUALITY, "0"));
+    }
+
+    public int mobileDefaultQuality() {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+        return Integer.parseInt(sp.getString(PREFERENCE_KEY_INTERNAL_MOBILE_DEFAULT_QUALITY, "0"));
     }
 
     public boolean initialSubscriptionMergeDone() {

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -64,7 +64,6 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.github.chrisbanes.photoview.PhotoView;
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.DefaultControlDispatcher;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.ParserException;
 import com.google.android.exoplayer2.PlaybackParameters;
@@ -1252,14 +1251,6 @@ public class FileViewFragment extends BaseFragment implements
         TextView textPlaybackSpeed = playerView.findViewById(R.id.player_playback_speed_label);
         textPlaybackSpeed.setText(DEFAULT_PLAYBACK_SPEED);
 
-        playerView.setControlDispatcher(new DefaultControlDispatcher() {
-            @Override
-            public boolean dispatchSetPlayWhenReady(Player player, boolean playWhenReady) {
-                isPlaying = playWhenReady;
-                return super.dispatchSetPlayWhenReady(player, playWhenReady);
-            }
-        });
-
         playbackSpeedContainer.setOnCreateContextMenuListener(new View.OnCreateContextMenuListener() {
             @Override
             public void onCreateContextMenu(ContextMenu contextMenu, View view, ContextMenu.ContextMenuInfo contextMenuInfo) {
@@ -1829,6 +1820,13 @@ public class FileViewFragment extends BaseFragment implements
             PlayerView view = root.findViewById(R.id.file_view_exoplayer_view);
             view.setShutterBackgroundColor(Color.TRANSPARENT);
             view.setPlayer(MainActivity.appPlayer);
+            view.getPlayer().addListener(new Player.Listener() {
+                @Override
+                public void onPlayWhenReadyChanged(boolean playWhenReady, int reason) {
+                    isPlaying = playWhenReady;
+                    Player.Listener.super.onPlayWhenReadyChanged(playWhenReady, reason);
+                }
+            });
             view.setUseController(true);
             if (context instanceof MainActivity) {
                 ((MainActivity) context).getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
@@ -3568,15 +3566,6 @@ public class FileViewFragment extends BaseFragment implements
     }
 
     public static class StreamLoadErrorPolicy extends DefaultLoadErrorHandlingPolicy {
-        @Override
-        public long getRetryDelayMsFor(int dataType, long loadDurationMs, IOException exception, int errorCount) {
-            return exception instanceof ParserException
-                    || exception instanceof FileNotFoundException
-                    || exception instanceof Loader.UnexpectedLoaderException
-                    ? C.TIME_UNSET
-                    : Math.min((errorCount - 1) * 1000, 5000);
-        }
-
         @Override
         public int getMinimumLoadableRetryCount(int dataType) {
             return Integer.MAX_VALUE;

--- a/app/src/main/java/com/odysee/app/utils/Helper.java
+++ b/app/src/main/java/com/odysee/app/utils/Helper.java
@@ -50,7 +50,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.TracksInfo;
+import com.google.android.exoplayer2.TracksInfo.TrackGroupInfo;
+import com.google.android.exoplayer2.source.TrackGroup;
 import com.odysee.app.MainActivity;
+import com.odysee.app.R;
 import com.odysee.app.data.DatabaseHelper;
 import com.odysee.app.dialog.ContentFromDialogFragment;
 import com.odysee.app.dialog.ContentSortDialogFragment;
@@ -86,6 +92,8 @@ public final class Helper {
     public static final SimpleDateFormat FILESTAMP_FORMAT =  new SimpleDateFormat("yyyyMMdd_HHmmss");
     public static final String EXPLORER_TX_PREFIX = "https://explorer.lbry.com/tx";
 
+    public static final int PLAYBACK_SPEEDS_GROUP_ID = 0;
+    public static final int QUALITIES_GROUP_ID = 1;
     public static final List<Double> PLAYBACK_SPEEDS = Arrays.asList(0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0);
 
     public static boolean isNull(String value) {
@@ -99,13 +107,35 @@ public final class Helper {
         int order = 0;
         DecimalFormat formatter = new DecimalFormat("0.##");
         for (Double speed : PLAYBACK_SPEEDS) {
-            menu.add(0, Double.valueOf(speed * 100).intValue(), ++order, String.format("%sx", formatter.format(speed)));
+            menu.add(PLAYBACK_SPEEDS_GROUP_ID, Double.valueOf(speed * 100).intValue(), ++order, String.format("%sx", formatter.format(speed)));
         }
     }
 
     public static String getDisplayValueForPlaybackSpeed(Double speed) {
         DecimalFormat formatter = new DecimalFormat("0.##");
         return String.format("%sx", formatter.format(speed));
+    }
+
+    public static void buildQualityMenu(ContextMenu menu, Player player, boolean isTranscoded) {
+        int order = 0;
+        menu.add(QUALITIES_GROUP_ID, 0, ++order, R.string.auto_quality);
+
+        if (isTranscoded) {
+            TracksInfo tracksInfo = player.getCurrentTracksInfo();
+            for (TrackGroupInfo groupInfo : tracksInfo.getTrackGroupInfos()) {
+                if (groupInfo.getTrackType() != C.TRACK_TYPE_VIDEO) continue;
+                TrackGroup group = groupInfo.getTrackGroup();
+
+                for (int i = 0; i < group.length; i++) {
+                    if (groupInfo.isTrackSupported(i)) {
+                        int quality = group.getFormat(i).height;
+                        menu.add(QUALITIES_GROUP_ID, quality, ++order, String.format("%sp", quality));
+                    }
+                }
+
+                break;
+            }
+        }
     }
 
     public static String capitalize(String value) {

--- a/app/src/main/res/layout/exo_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_playback_control_view.xml
@@ -101,7 +101,7 @@
         android:clickable="true"
         android:focusable="true"
         android:layout_alignParentBottom="true"
-        android:layout_width="56dp"
+        android:layout_width="40dp"
         android:layout_height="48dp"
         android:layout_toStartOf="@id/player_toggle_fullscreen">
         <TextView
@@ -110,7 +110,29 @@
             android:layout_centerVertical="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
+            android:fontFamily="@font/inter"
+            android:letterSpacing="0.05"
+            android:singleLine="true"
+            android:textColor="@color/white"
+            android:textSize="11sp" />
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/player_quality"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:layout_alignParentBottom="true"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_toStartOf="@id/player_playback_speed">
+
+        <TextView
+            android:id="@+id/player_quality_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
             android:fontFamily="@font/inter"
             android:letterSpacing="0.05"
             android:singleLine="true"
@@ -137,10 +159,11 @@
     </RelativeLayout>
 
     <RelativeLayout
+        android:id="@+id/player_duration_elapsed_container"
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:layout_alignParentBottom="true"
-        android:layout_toStartOf="@id/player_playback_speed"
+        android:layout_toStartOf="@id/player_quality"
         android:paddingStart="16dp"
         android:paddingEnd="4dp">
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,8 @@
     <string name="enable_background_playback">Enable background playback</string>
     <string name="enable_background_playback_pip_mode">Continue playing media in the background after closing picture-in-picture mode</string>
     <string name="enable_autoplay">Autoplay media files</string>
+    <string name="wifi_default_quality">Default quality</string>
+    <string name="mobile_default_quality">Default quality when using mobile data</string>
     <string name="enable_dark_mode">Enable dark theme</string>
     <string name="enable_autosearch">Perform search while typing</string>
     <string name="show_mature_content">Show mature content</string>
@@ -308,6 +310,21 @@
 
     <string name="participate_in_data_network">Participate in the data network (requires app and background service restart)</string>
     <string name="send_buffering_events">Send buffering events to LBRY servers</string>
+
+    <string-array name="available_qualities">
+        <item>@string/auto_quality</item>
+        <item>1080p</item>
+        <item>720p</item>
+        <item>360p</item>
+        <item>144p</item>
+    </string-array>
+    <string-array name="available_qualities_values">
+        <item>0</item> <!-- Auto Quality selection -->
+        <item>1080</item>
+        <item>720</item>
+        <item>360</item>
+        <item>144</item>
+    </string-array>
 
     <!-- URL suggestions -->
     <string name="search_url_title">%1$s - Search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="publish_something_here">Publish something here</string>
     <string name="cannot_view_claim">This content cannot be accessed at this time. Please try again later.</string>
     <string name="zero_duration">0:00</string>
+    <string name="auto_quality">Auto</string>
     <string name="claim_file_not_found">The file at "%1$s" does not exist.</string>
     <string name="confirm_purchase">Confirm Purchase</string>
     <string name="delete_file">Delete file</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -24,6 +24,24 @@
             app:title="@string/enable_autoplay"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
+        <DropDownPreference
+            app:key="com.odysee.app.preference.userinterface.WifiDefaultQuality"
+            app:entries="@array/available_qualities"
+            app:entryValues="@array/available_qualities_values"
+            app:defaultValue="@string/auto_quality"
+            app:title="@string/wifi_default_quality"
+            app:singleLineTitle="false"
+            app:summary="%s"
+            app:iconSpaceReserved="false" />
+        <DropDownPreference
+            app:key="com.odysee.app.preference.userinterface.MobileDefaultQuality"
+            app:entries="@array/available_qualities"
+            app:entryValues="@array/available_qualities_values"
+            app:defaultValue="@string/auto_quality"
+            app:title="@string/mobile_default_quality"
+            app:singleLineTitle="false"
+            app:summary="%s"
+            app:iconSpaceReserved="false" />
         <SwitchPreferenceCompat
             app:key="com.odysee.app.preference.userinterface.DarkMode"
             app:title="@string/enable_dark_mode"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #113 

## What is the current behavior?

No quality selector

## What is the new behavior?

Quality selector next to the speed selector.

- An `Auto` selection to let Exoplayer decide the best quality to use (also for non-transcoded videos)
- Settings for default qualities on Wi-Fi or Mobile Data

| Player view | Settings |
|--|--|
| <img height="500" alt="Player view" src="https://user-images.githubusercontent.com/71804605/159434445-584f730a-167a-4932-92ec-3193563ec341.png"/> | <img height="500" alt="Settings" src="https://user-images.githubusercontent.com/71804605/159434603-d7dd05da-3a31-4f18-863f-714cd1efe120.png"/> |

## Note

The Exoplayer dependency is bumped to 2.16.0 to allow using the new track selection APIs. To the best of my knowledge this didn't break anything, but I didn't test live streams.