### PR TITLE
Fix all items being filtered out on Library tab

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -688,7 +688,10 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                 isAudio = mediaType.startsWith(Claim.STREAM_TYPE_AUDIO);
             }
         }
-        return (Claim.TYPE_COLLECTION.equalsIgnoreCase(claim.getValueType()) && !filterByChannel) || (((claimFileTypes.contains(Claim.STREAM_TYPE_VIDEO) && isVideo) || (claimFileTypes.contains(Claim.STREAM_TYPE_AUDIO) && isAudio)) && (filterByFile || !filterByChannel));
+        return (Claim.TYPE_COLLECTION.equalsIgnoreCase(claim.getValueType()) && !filterByChannel)
+                || (!filterByFile && !filterByChannel)
+                || (((claimFileTypes.contains(Claim.STREAM_TYPE_VIDEO) && isVideo) || (claimFileTypes.contains(Claim.STREAM_TYPE_AUDIO) && isAudio))
+                     && filterByFile);
     }
 
     private void toggleSelectedClaim(Claim claim) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Library tab will always appear as blank
## What is the new behavior?
Items are shown again
## Other information
This was caused by my previous PR for filtering search results.
