### PR TITLE
Fix CreditsBalanceView position on channel creator dialog

### DIFF
--- a/app/src/main/res/layout/channel_form_bottom_sheet.xml
+++ b/app/src/main/res/layout/channel_form_bottom_sheet.xml
@@ -34,7 +34,7 @@
             android:textSize="14sp" />
     </com.google.android.material.textfield.TextInputLayout>
 
-    <RelativeLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_marginTop="16dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
@@ -42,6 +42,9 @@
             android:id="@+id/inline_channel_form_layout_deposit"
             android:layout_width="100dp"
             android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             android:hint="@string/deposit">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/inline_channel_form_input_deposit"
@@ -56,11 +59,13 @@
 
         <TextView
             android:id="@+id/inline_channel_form_inline_currency"
-            android:layout_toEndOf="@id/inline_channel_form_layout_deposit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="30dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/inline_channel_form_layout_deposit"
             style="@style/TextView_Light"
             android:text="@string/lbc"
             android:textAllCaps="true"
@@ -68,15 +73,17 @@
 
         <com.odysee.app.views.CreditsBalanceView
             android:id="@+id/channel_form_balanceview"
-            android:layout_toEndOf="@id/inline_channel_form_inline_currency"
-            android:layout_marginStart="24dp"
-            android:layout_marginTop="28dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/inline_channel_form_inline_currency"
+            android:layout_marginStart="24dp"
             app:iconSize="12dp"
             android:visibility="invisible"
             tools:visibility="visible" />
-    </RelativeLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView
         android:layout_width="wrap_content"
@@ -95,15 +102,18 @@
             android:id="@+id/inline_channel_form_cancel_link"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
             android:background="?attr/selectableItemBackground"
             android:clickable="true"
             android:focusable="true"
             android:fontFamily="@font/inter"
+            android:gravity="center_vertical"
             android:text="@string/cancel"
-            android:textSize="12sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:textSize="12sp" />
 
         <ProgressBar
             android:id="@+id/inline_channel_form_create_progress"

--- a/app/src/main/res/layout/fragment_channel_form.xml
+++ b/app/src/main/res/layout/fragment_channel_form.xml
@@ -174,14 +174,17 @@
                             android:visibility="gone" />
                     </RelativeLayout>
 
-                    <RelativeLayout
-                        android:layout_marginTop="16dp"
+                    <androidx.constraintlayout.widget.ConstraintLayout
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="16dp">
                         <com.google.android.material.textfield.TextInputLayout
                             android:id="@+id/channel_form_input_layout_deposit"
                             android:layout_width="100dp"
                             android:layout_height="wrap_content"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
                             android:hint="@string/deposit">
                             <com.google.android.material.textfield.TextInputEditText
                                 android:id="@+id/channel_form_input_deposit"
@@ -198,19 +201,26 @@
                             android:layout_toEndOf="@id/channel_form_input_layout_deposit"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/channel_form_input_layout_deposit"
                             android:layout_marginStart="8dp"
                             android:layout_marginTop="30dp"
                             style="@style/TextView_Light"
                             android:text="@string/lbc"
                             android:textAllCaps="true"
-                            android:textSize="11sp" />
-
-                        <com.odysee.app.views.CreditsBalanceView android:id="@+id/channel_form_balance"
+                            android:textSize="11sp"/>
+                        <com.odysee.app.views.CreditsBalanceView
+                            android:id="@+id/channel_form_balance"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            app:layout_constraintStart_toEndOf="@id/channel_form_input_currency"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            android:layout_marginStart="24dp"
                             android:visibility="invisible"
                             tools:visibility="visible" />
-                    </RelativeLayout>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -287,27 +297,34 @@
                         android:layout_marginTop="24dp">
                         <TextView
                             android:id="@+id/channel_form_cancel_link"
-                            android:background="?attr/selectableItemBackground"
-                            android:clickable="true"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
+                            android:background="?attr/selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
                             android:fontFamily="@font/inter"
-                            android:textSize="14sp"
-                            android:text="@string/cancel" />
+                            android:gravity="center_vertical"
+                            android:minWidth="48dp"
+                            android:minHeight="48dp"
+                            android:text="@string/cancel"
+                            android:textSize="14sp"/>
 
                         <TextView
                             android:id="@+id/channel_form_toggle_optional"
-                            android:background="?attr/selectableItemBackground"
-                            android:clickable="true"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
                             android:layout_marginEnd="24dp"
                             android:layout_toStartOf="@id/channel_form_save_button"
+                            android:background="?attr/selectableItemBackground"
+                            android:clickable="true"
                             android:fontFamily="@font/inter"
+                            android:minHeight="48dp"
+                            android:gravity="center_vertical"
+                            android:text="@string/show_optional_fields"
                             android:textSize="14sp"
-                            android:text="@string/show_optional_fields" />
+                            android:focusable="true"/>
                         <ProgressBar
                             android:id="@+id/channel_form_save_progress"
                             android:layout_width="20dp"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
View is displayed at start of line
## What is the new behavior?
Position is now correct one
## Other information
Some other changes has been done to improve area of clickable views