### PR TITLE
Switch Clear All icon depending on Search UI

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -3382,6 +3382,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             findViewById(R.id.wunderbar_notifications).setVisibility(View.GONE);
             findViewById(R.id.search_query_layout).setVisibility(View.VISIBLE);
             findViewById(R.id.search_close_button).setVisibility(View.VISIBLE);
+            switchClearViewHistoryButton(false);
         } else {
             EditText queryTextView = findViewById(R.id.search_query_text);
             queryTextView.setText("");
@@ -3392,6 +3393,12 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             findViewById(R.id.upload_button).setVisibility(View.VISIBLE);
             findViewById(R.id.profile_button).setVisibility(View.VISIBLE);
             findViewById(R.id.wunderbar_notifications).setVisibility(View.VISIBLE);
+
+            if (((BottomNavigationView) findViewById(R.id.bottom_navigation)).getSelectedItemId() == R.id.action_library_menu) {
+                switchClearViewHistoryButton(true);
+            } else {
+                switchClearViewHistoryButton(false);
+            }
         }
     }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Clear All menu item is not removed when entering Search UI
## What is the new behavior?
Now it is removed and shown again when returning to Library tab page