### PR TITLE
- Fix crash caused when sorting comments with no reactions

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -3268,7 +3268,11 @@ public class FileViewFragment extends BaseFragment implements
                             public int compare(Comment o1, Comment o2) {
                                 int o1SelfLiked = (Lbryio.isSignedIn() &&  o1.getReactions() != null && o1.getReactions().isLiked()) ? 1 : 0;
                                 int o2SelfLiked = (Lbryio.isSignedIn() && o2.getReactions() != null && o2.getReactions().isLiked()) ? 1 : 0;
-                                return (o2.getReactions().getOthersLikes() + o2SelfLiked) - (o1.getReactions().getOthersLikes() + o1SelfLiked);
+
+                                int o1OtherLikes = o1.getReactions() != null ? o1.getReactions().getOthersLikes() : 0;
+                                int o2OtherLikes = o2.getReactions() != null ? o2.getReactions().getOthersLikes() : 0;
+
+                                return (o2OtherLikes + o2SelfLiked) - (o1OtherLikes + o1SelfLiked);
                             }
                         });
                     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 177

## What is the current behavior?
The application crashes with an npe when comments will null reactions are also sorted while playing a video

## What is the new behavior?
No crash is observed while playing certain videos which triggered the crash

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
