### PR TITLE
Fixed some issues

### DIFF
--- a/app/src/main/java/com/odysee/app/dialog/CreateSupportDialogFragment.java
+++ b/app/src/main/java/com/odysee/app/dialog/CreateSupportDialogFragment.java
@@ -14,12 +14,12 @@ import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CompoundButton;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatSpinner;
 import androidx.core.text.HtmlCompat;
 
@@ -85,6 +85,7 @@ public class CreateSupportDialogFragment extends BottomSheetDialogFragment imple
         this.listener = listener;
     }
 
+    @NonNull
     public static CreateSupportDialogFragment newInstance(Claim claim, CreateSupportListener listener) {
         return new CreateSupportDialogFragment(claim, listener);
     }
@@ -187,7 +188,7 @@ public class CreateSupportDialogFragment extends BottomSheetDialogFragment imple
                 }
 
                 BigDecimal amount = new BigDecimal(amountString);
-                if (amount.doubleValue() > Lbry.walletBalance.getAvailable().doubleValue()) {
+                if (amount.doubleValue() > Lbry.getAvailableBalance()) {
                     showError(getString(R.string.insufficient_balance));
                     return;
                 }
@@ -343,7 +344,7 @@ public class CreateSupportDialogFragment extends BottomSheetDialogFragment imple
     }
 
     private void fetchChannels() {
-        if (Lbry.ownChannels != null && Lbry.ownChannels.size() > 0) {
+        if (Lbry.ownChannels != null && !Lbry.ownChannels.isEmpty()) {
             updateChannelList(Lbry.ownChannels);
             return;
         }
@@ -400,6 +401,7 @@ public class CreateSupportDialogFragment extends BottomSheetDialogFragment imple
         }
     }
 
+    @Override
     public void onResume() {
         super.onResume();
         Context context = getContext();
@@ -410,6 +412,7 @@ public class CreateSupportDialogFragment extends BottomSheetDialogFragment imple
         fetchChannels();
     }
 
+    @Override
     public void onPause() {
         Context context = getContext();
         if (context instanceof MainActivity) {
@@ -426,10 +429,12 @@ public class CreateSupportDialogFragment extends BottomSheetDialogFragment imple
     }
 
     private void showError(String message) {
-        Snackbar.make(getView(), message, Snackbar.LENGTH_LONG).
+        if (getView() != null) {
+            Snackbar.make(getView(), message, Snackbar.LENGTH_LONG).
                 setBackgroundTint(Color.RED).
                 setTextColor(Color.WHITE).
                 show();
+        }
     }
 
     public interface CreateSupportListener {

--- a/app/src/main/java/com/odysee/app/dialog/RepostClaimDialogFragment.java
+++ b/app/src/main/java/com/odysee/app/dialog/RepostClaimDialogFragment.java
@@ -146,6 +146,7 @@ public class RepostClaimDialogFragment extends BottomSheetDialogFragment impleme
         return view;
     }
 
+    @Override
     public void onResume() {
         super.onResume();
         Context context = getContext();
@@ -155,6 +156,7 @@ public class RepostClaimDialogFragment extends BottomSheetDialogFragment impleme
         fetchChannels();
     }
 
+    @Override
     public void onPause() {
         Context context = getContext();
         if (context instanceof MainActivity) {
@@ -230,7 +232,7 @@ public class RepostClaimDialogFragment extends BottomSheetDialogFragment impleme
         }
 
         BigDecimal bid = new BigDecimal(depositString);
-        if (bid.doubleValue() > Lbry.walletBalance.getAvailable().doubleValue()) {
+        if (bid.doubleValue() > Lbry.getAvailableBalance()) {
             showError(getString(R.string.insufficient_balance));
             return;
         }

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelCommentsFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelCommentsFragment.java
@@ -10,7 +10,6 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
@@ -101,7 +100,7 @@ public class ChannelCommentsFragment extends Fragment implements ChannelCreateDi
         commentEnabledCheck = new CommentEnabledCheck();
     }
 
-
+    @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.fragment_channel_comments, container, false);
@@ -140,6 +139,7 @@ public class ChannelCommentsFragment extends Fragment implements ChannelCreateDi
         commentsNestedLayout.setVisibility(View.GONE);
     }
 
+    @Override
     public void onResume() {
         super.onResume();
 
@@ -148,6 +148,7 @@ public class ChannelCommentsFragment extends Fragment implements ChannelCreateDi
         applyFilterForBlockedChannels(Lbryio.blockedChannels);
     }
 
+    @Override
     public void onStop() {
         super.onStop();
     }
@@ -715,7 +716,7 @@ public class ChannelCommentsFragment extends Fragment implements ChannelCreateDi
                     showError(error);
                     return;
                 }
-                if (Lbry.walletBalance == null || Lbry.walletBalance.getAvailable().doubleValue() < depositAmount) {
+                if (Lbry.walletBalance == null || Lbry.getAvailableBalance() < depositAmount) {
                     showError(getString(R.string.deposit_more_than_balance));
                     return;
                 }
@@ -770,6 +771,6 @@ public class ChannelCommentsFragment extends Fragment implements ChannelCreateDi
             }
         });
 
-        Helper.setViewText(inlineBalanceValue, Helper.shortCurrencyFormat(Lbry.walletBalance.getAvailable().doubleValue()));
+        Helper.setViewText(inlineBalanceValue, Helper.shortCurrencyFormat(Lbry.getAvailableBalance()));
     }
 }

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelCreateDialogFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelCreateDialogFragment.java
@@ -104,7 +104,7 @@ public class ChannelCreateDialogFragment extends BottomSheetDialogFragment {
                     showError(error);
                     return;
                 }
-                if (Lbry.walletBalance == null || Lbry.walletBalance.getAvailable().doubleValue() < depositAmount) {
+                if (Lbry.walletBalance == null || Lbry.getAvailableBalance() < depositAmount) {
                     showError(getString(R.string.deposit_more_than_balance));
                     return;
                 }
@@ -177,8 +177,7 @@ public class ChannelCreateDialogFragment extends BottomSheetDialogFragment {
             }
         });
 
-        double balance = Lbry.walletBalance.getAvailable().doubleValue();
-        Helper.setViewText((TextView) balanceView, Helper.shortCurrencyFormat(balance));
+        Helper.setViewText((TextView) balanceView, Helper.shortCurrencyFormat(Lbry.getAvailableBalance()));
         return v;
     }
 

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelFormFragment.java
@@ -109,6 +109,7 @@ public class ChannelFormFragment extends BaseFragment implements
     private String lastSelectedCoverFile;
     private String lastSelectedThumbnailFile;
 
+    @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.fragment_channel_form, container, false);
@@ -328,7 +329,7 @@ public class ChannelFormFragment extends BaseFragment implements
             showError(error);
             return;
         }
-        if (Lbry.walletBalance == null || Lbry.walletBalance.getAvailable().doubleValue() < depositAmount) {
+        if (Lbry.getAvailableBalance() < depositAmount) {
             showError(getString(R.string.deposit_more_than_balance));
             return;
         }

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -317,6 +317,7 @@ public class FileViewFragment extends BaseFragment implements
         commentEnabledCheck = new CommentEnabledCheck();
     }
 
+    @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.fragment_file_view, container, false);
@@ -441,6 +442,7 @@ public class FileViewFragment extends BaseFragment implements
         }
     }
 
+    @Override
     public void onStart() {
         super.onStart();
         Context context = getContext();
@@ -844,6 +846,8 @@ public class FileViewFragment extends BaseFragment implements
         resetPlayer();
     }
 */
+
+    @Override
     public void onResume() {
         super.onResume();
         checkParams();
@@ -887,6 +891,7 @@ public class FileViewFragment extends BaseFragment implements
         applyFilterForBlockedChannels(Lbryio.blockedChannels);
     }
 
+    @Override
     public void onPause() {
         if (MainActivity.appPlayer != null) {
             MainActivity.nowPlayingSource = MainActivity.SOURCE_NOW_PLAYING_FILE;
@@ -898,6 +903,7 @@ public class FileViewFragment extends BaseFragment implements
         super.onPause();
     }
 
+    @Override
     public void onStop() {
         super.onStop();
         Context context = getContext();
@@ -1072,7 +1078,7 @@ public class FileViewFragment extends BaseFragment implements
         ResolveTask task = new ResolveTask(url, Lbry.API_CONNECTION_STRING, layoutResolving, new ClaimListResultHandler() {
             @Override
             public void onSuccess(List<Claim> claims) {
-                if (claims.size() > 0 && !Helper.isNullOrEmpty(claims.get(0).getClaimId())) {
+                if (!claims.isEmpty() && !Helper.isNullOrEmpty(claims.get(0).getClaimId())) {
                     fileClaim = claims.get(0);
                     if (Claim.TYPE_REPOST.equalsIgnoreCase(fileClaim.getValueType())) {
                         fileClaim = fileClaim.getRepostedClaim();
@@ -2043,6 +2049,11 @@ public class FileViewFragment extends BaseFragment implements
                     MainActivity.appPlayer.setPlayWhenReady(true);
                     playbackStarted = true;
 
+                    if (context instanceof MainActivity) {
+                        MainActivity activity = (MainActivity) context;
+                        activity.displayCurrentlyPlayingVideo();
+                    }
+
                     // reconnect the app player
                     if (fileViewPlayerListener != null) {
                         MainActivity.appPlayer.addListener(fileViewPlayerListener);
@@ -2535,7 +2546,7 @@ public class FileViewFragment extends BaseFragment implements
                 jsonParams.put("auth_token", am.peekAuthToken(odyseeAccount, "auth_token_type"));
             }
 
-            if (Lbry.ownChannels.size() > 0) {
+            if (!Lbry.ownChannels.isEmpty()) {
                 jsonParams.put("channel_id", Lbry.ownChannels.get(0).getClaimId());
                 jsonParams.put("channel_name", Lbry.ownChannels.get(0).getName());
 
@@ -3025,6 +3036,7 @@ public class FileViewFragment extends BaseFragment implements
         checkAndLoadComments(true);
     }
 
+    @Override
     public void showError(String message) {
         View root = getView();
         if (root != null) {
@@ -3463,6 +3475,7 @@ public class FileViewFragment extends BaseFragment implements
         }
     }
 
+    @Override
     public boolean onBackPressed() {
         if (isInFullscreenMode()) {
             disableFullScreenMode();
@@ -4037,7 +4050,7 @@ public class FileViewFragment extends BaseFragment implements
     }
 
     private void fetchChannels() {
-        if (Lbry.ownChannels != null && Lbry.ownChannels.size() > 0) {
+        if (Lbry.ownChannels != null && !Lbry.ownChannels.isEmpty()) {
             updateChannelList(Lbry.ownChannels);
             return;
         }
@@ -4331,8 +4344,13 @@ public class FileViewFragment extends BaseFragment implements
             Helper.setViewVisibility(relatedContentArea, View.VISIBLE);
             Helper.setViewVisibility(actionsArea, View.VISIBLE);
             Helper.setViewVisibility(publisherArea, View.VISIBLE);
-            if (context != null)
+            if (context != null) {
                 expandButton.setImageDrawable(getResources().getDrawable(R.drawable.ic_expand, context.getTheme()));
+                InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(root.getWindowToken(), 0);
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
@@ -427,7 +427,7 @@ public class PublishFormFragment extends BaseFragment implements
                     showError(error);
                     return;
                 }
-                if (Lbry.walletBalance == null || Lbry.walletBalance.getAvailable().doubleValue() < depositAmount) {
+                if (Lbry.getAvailableBalance() < depositAmount) {
                     showError(getString(R.string.deposit_more_than_balance));
                     return;
                 }

--- a/app/src/main/java/com/odysee/app/ui/wallet/WalletFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/wallet/WalletFragment.java
@@ -248,8 +248,7 @@ public class WalletFragment extends BaseFragment implements WalletBalanceListene
         if (!Helper.isNullOrEmpty(amountString)) {
             try {
                 double amountValue = Double.parseDouble(amountString);
-                double availableAmount = Lbry.walletBalance.getAvailable().doubleValue();
-                if (availableAmount < amountValue) {
+                if (Lbry.getAvailableBalance() < amountValue) {
                     Snackbar.make(getView(), R.string.insufficient_balance, Snackbar.LENGTH_LONG).
                             setBackgroundTint(Color.RED).setTextColor(Color.WHITE).show();
                     return false;
@@ -656,6 +655,9 @@ public class WalletFragment extends BaseFragment implements WalletBalanceListene
     }
 
     public void onWalletBalanceUpdated(WalletBalance walletBalance) {
+        if (walletBalance == null) {
+            return;
+        }
         double totalBalance = walletBalance.getTotal().doubleValue();
         double spendableBalance = walletBalance.getAvailable().doubleValue();
         double supportingBalance = walletBalance.getClaims().doubleValue() + walletBalance.getTips().doubleValue() + walletBalance.getSupports().doubleValue();

--- a/app/src/main/java/com/odysee/app/utils/Lbry.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbry.java
@@ -113,12 +113,24 @@ public final class Lbry {
     public static KeyStore KEYSTORE;
     public static boolean SDK_READY = false;
 
+    private Lbry() {
+        // Ignore
+    }
+
     public static void startupInit() {
         abandonedClaimIds = new ArrayList<>();
         ownChannels = new ArrayList<>();
         ownClaims = new ArrayList<>();
         knownTags = new ArrayList<>();
         followedTags = new ArrayList<>();
+    }
+
+    public static double getTotalBalance() {
+        return walletBalance != null ? walletBalance.getTotal().doubleValue() : 0;
+    }
+
+    public static double getAvailableBalance() {
+        return walletBalance != null ? Lbry.walletBalance.getAvailable().doubleValue() : 0;
     }
 
     public static void parseStatus(String response) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
- Crashed occurred when fetching available and total wallet balances. This can be reproduced when navigating to the Wallet tab with no data connection on the device
- When in pip mode, if the "Allow picture-in-picture" setting is switched off and the app is launched, the video is resumed but neither the mini player nor the main player is shown (main player => Player in FileViewFragment)
- There was a flickering of an error text when you navigate to the Following tab if there was no data connection. 

## What is the new behavior?
- Added null checks when retrieving the wallet's available and total balances. Also prevented the wallet details from being updated if the wallet object is null
- Toggled the visibility of the FileViewFragment to show when a video is already playing and the mini player is not visible.
- Fetch the followed channels at delayed intervals (every 5 second) when there's no data connection to reduce the flickering.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
