### PR TITLE
A new fix for the Discover link shifting to the left on some devices

### DIFF
--- a/app/src/main/res/layout-sw360dp/fragment_following.xml
+++ b/app/src/main/res/layout-sw360dp/fragment_following.xml
@@ -46,7 +46,7 @@
                 android:layout_alignParentEnd="true" />
         </RelativeLayout>
 
-        <RelativeLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/following_filter_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -59,6 +59,9 @@
                           android:background="?attr/selectableItemBackground"
                           android:layout_width="wrap_content"
                           android:layout_height="wrap_content"
+                          app:layout_constraintStart_toStartOf="parent"
+                          app:layout_constraintTop_toTopOf="parent"
+                          app:layout_constraintBottom_toBottomOf="parent"
                           android:layout_centerVertical="true"
                           android:minHeight="48dp"
                           android:visibility="gone"
@@ -82,10 +85,12 @@
             </LinearLayout>
 
             <LinearLayout android:id="@+id/following_sort_link"
-                android:layout_toEndOf="@id/filter_by_channel_link"
                 android:background="?attr/selectableItemBackground"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                app:layout_constraintStart_toEndOf="@id/filter_by_channel_link"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 android:layout_marginStart="16dp"
                 android:layout_centerVertical="true"
                 android:minHeight="48dp"
@@ -114,7 +119,9 @@
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_marginStart="8dp"
-                android:layout_toEndOf="@id/following_sort_link"
+                app:layout_constraintStart_toEndOf="@id/following_sort_link"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 android:background="?attr/selectableItemBackground"
                 android:clickable="true"
                 android:focusable="true"
@@ -146,7 +153,9 @@
                 android:layout_centerVertical="true"
                 android:layout_marginEnd="4dp"
                 android:minHeight="48dp"
-                android:layout_toStartOf="@id/following_content_progress"
+                app:layout_constraintEnd_toStartOf="@id/following_content_progress"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 android:background="?attr/selectableItemBackground"
                 android:clickable="true"
                 android:focusable="true"
@@ -158,9 +167,11 @@
                 android:visibility="invisible"
                 android:layout_width="16dp"
                 android:layout_height="16dp"
-                android:layout_centerVertical="true"
-                android:layout_alignParentEnd="true" />
-        </RelativeLayout>
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_centerVertical="true" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <TextView
             android:id="@+id/following_page_info"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
On one of my test devices, the Discover link on Following fragment moves to the left. This was fixed on a previous commit, but after a device update, this is happenning again.
## What is the new behavior?
Link is again fixed to the right