### PR TITLE
Show credits icon at design-time for CreditsBalanceView

### DIFF
--- a/app/src/main/java/com/odysee/app/views/CreditsBalanceView.java
+++ b/app/src/main/java/com/odysee/app/views/CreditsBalanceView.java
@@ -23,6 +23,7 @@ public class CreditsBalanceView extends TextView {
     private float iconSize;
     Rect r;
     Paint p;
+    Drawable icon;
 
     public CreditsBalanceView(Context context) {
         super(context);
@@ -48,6 +49,10 @@ public class CreditsBalanceView extends TextView {
             float px = 8 * (metrics.densityDpi / 160f);
 
             setPadding((int) iconSize + Math.round(px), 0, 0, 0);
+            //noinspection UseCompatLoadingForDrawables
+            icon = getResources().getDrawable(R.drawable.ic_credits, context.getTheme());
+        } catch (Exception e) {
+            e.printStackTrace();
         } finally {
             a.recycle();
         }
@@ -62,13 +67,10 @@ public class CreditsBalanceView extends TextView {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        drawLbryCredits(canvas);
-    }
-
-    private void drawLbryCredits(Canvas c) {
-        @SuppressLint("UseCompatLoadingForDrawables") Drawable icon = getResources().getDrawable(R.drawable.ic_credits, null);
-        float delta = (c.getHeight() - iconSize) / 2;
-        icon.setBounds(0, (int) delta, (int) iconSize, (int) (delta + iconSize));
-        icon.draw(c);
+        if (getText().length() > 0) {
+            float delta = (getHeight() - iconSize) / 2;
+            icon.setBounds(0, (int) delta, (int) iconSize, (int) (delta + iconSize));
+            icon.draw(canvas);
+        }
     }
 }

--- a/app/src/main/res/layout/card_wallet_balance.xml
+++ b/app/src/main/res/layout/card_wallet_balance.xml
@@ -21,6 +21,7 @@
                 android:layout_height="wrap_content"
                 lbry:textSize="@dimen/wallet_total_balance_font_size"
                 lbry:iconSize="24dp"
+                tools:text="123.45"
                 android:textFontWeight="300" />
 
             <TextView
@@ -51,6 +52,7 @@
                     android:layout_height="wrap_content"
                     lbry:textSize="@dimen/wallet_detail_balance_font_size"
                     lbry:iconSize="14dp"
+                    tools:text="67.89"
                     android:textFontWeight="300" />
 
                 <TextView


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
When a CreditsBalanceView is displayed on the LayoutEditor, the credits icon is not shown, although space is reserved.
## What is the new behavior?
The icon is now shown