### PR TITLE
Show the Clear All button on Library (regression fix)

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/library/LibraryFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/library/LibraryFragment.java
@@ -631,6 +631,12 @@ public class LibraryFragment extends BaseFragment implements
         boolean hasRecent = contentListAdapter != null && contentListAdapter.getItemCount() > 0;
         Helper.setViewVisibility(recentList, hasRecent ? View.VISIBLE : View.GONE);
         Helper.setViewVisibility(textNoHistory, !hasRecent ? View.VISIBLE : View.GONE);
+
+        // The "Clear All" button is shown at the main app toolbar, so its visibility is changed from MainActivity instance
+        MainActivity a = (MainActivity) getActivity();
+        if (a != null) {
+            a.switchClearViewHistoryButton(currentFilter == FILTER_HISTORY && contentListAdapter != null && contentListAdapter.getItemCount() > 0);
+        }
     }
 
     @MainThread


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
The clear all button is not shown on the Library fragment
## What is the new behavior?
The button is shown again
## Other information
Fix regression caused by PR 179
