### PR TITLE
Use correct Content-Type for transcoded HLS content

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2136,11 +2136,15 @@ public class FileViewFragment extends BaseFragment implements
                         .build();
                 try (Response response = client.newCall(request).execute()) {
                     String contentType = response.header("Content-Type");
-                    MainActivity.videoIsTranscoded = contentType.equals("application/x-mpegurl"); // m3u8
+                    if (contentType != null) {
+                        MainActivity.videoIsTranscoded = contentType.equals("application/vnd.apple.mpegurl") || contentType.equals("audio/mpegurl"); // HLS
+                    }
+                } catch (Exception ex) {
+                    ex.printStackTrace();
                 }
 
                 new Handler(Looper.getMainLooper()).post(() -> initializePlayer(sourceUrl));
-            } catch (LbryRequestException | LbryResponseException | JSONException | IOException ex) {
+            } catch (LbryRequestException | LbryResponseException | JSONException ex) {
                 // TODO: How does error handling work here
                 ex.printStackTrace();
             }
@@ -2164,9 +2168,7 @@ public class FileViewFragment extends BaseFragment implements
                     .setLoadErrorHandlingPolicy(new StreamLoadErrorPolicy())
                     .createMediaSource(MediaItem.fromUri(sourceUrl));
         } else {
-            mediaSource = new ProgressiveMediaSource.Factory(
-                    cacheDataSourceFactory, new DefaultExtractorsFactory()
-            )
+            mediaSource = new ProgressiveMediaSource.Factory(cacheDataSourceFactory, new DefaultExtractorsFactory())
                     .setLoadErrorHandlingPolicy(new StreamLoadErrorPolicy())
                     .createMediaSource(MediaItem.fromUri(sourceUrl));
         }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Media is not being played because ExoPlayer cannot find an EXTM3U header
## What is the new behavior?
The EXTM3U header is not search for when content is not from an HLS media source. The correct Content-Type has been extracted from Wikipedia page [https://en.wikipedia.org/wiki/HTTP_Live_Streaming](https://en.wikipedia.org/wiki/HTTP_Live_Streaming)