### PR TITLE
Show images and markdown posts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,7 +113,12 @@ dependencies {
     implementation 'com.hbb20:ccp:2.5.3'
 
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
-    implementation 'com.atlassian.commonmark:commonmark:0.14.0'
+    implementation 'org.commonmark:commonmark:0.18.1'
+    implementation 'org.commonmark:commonmark-ext-autolink:0.18.1'
+    implementation 'org.commonmark:commonmark-ext-gfm-strikethrough:0.18.1'
+    implementation 'org.commonmark:commonmark-ext-gfm-tables:0.18.1'
+    implementation 'org.commonmark:commonmark-ext-ins:0.18.1'
+    implementation 'org.commonmark:commonmark-ext-task-list-items:0.18.1'
 
     implementation 'com.arthenica:mobile-ffmpeg-full:4.4.LTS'
     implementation 'commons-codec:commons-codec:1.15'

--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -107,9 +107,11 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         notFoundClaimIdMap = new HashMap<>();
         notFoundClaimUrlMap = new HashMap<>();
 
-        claimFileTypes = new ArrayList<>(2);
+        claimFileTypes = new ArrayList<>(4);
         claimFileTypes.add(Claim.STREAM_TYPE_VIDEO);
         claimFileTypes.add(Claim.STREAM_TYPE_AUDIO);
+        claimFileTypes.add(Claim.STREAM_TYPE_IMAGE);
+        claimFileTypes.add(Claim.STREAM_TYPE_TEXT);
     }
 
     public List<Claim> getSelectedItems() {
@@ -280,7 +282,12 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         notifyDataSetChanged();
     }
 
-    public void setFileTypeFilters(@Nullable Boolean showVideos, @Nullable Boolean showAudios) {
+    public void setFileTypeFilters(
+            @Nullable Boolean showVideos,
+            @Nullable Boolean showAudios,
+            @Nullable Boolean showImages,
+            @Nullable Boolean showTexts
+    ) {
         if (claimFileTypes != null) {
             if (showVideos != null && showVideos && !claimFileTypes.contains(Claim.STREAM_TYPE_VIDEO)) {
                 claimFileTypes.add(Claim.STREAM_TYPE_VIDEO);
@@ -292,6 +299,18 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                 claimFileTypes.add(Claim.STREAM_TYPE_AUDIO);
             } else if (showAudios != null && !showAudios && claimFileTypes.contains(Claim.STREAM_TYPE_AUDIO)) {
                 claimFileTypes.remove(Claim.STREAM_TYPE_AUDIO);
+            }
+
+            if (showImages != null && showImages && !claimFileTypes.contains(Claim.STREAM_TYPE_IMAGE)) {
+                claimFileTypes.add(Claim.STREAM_TYPE_IMAGE);
+            } else if (showImages != null && !showImages && claimFileTypes.contains(Claim.STREAM_TYPE_IMAGE)) {
+                claimFileTypes.remove(Claim.STREAM_TYPE_IMAGE);
+            }
+
+            if (showTexts != null && showTexts && !claimFileTypes.contains(Claim.STREAM_TYPE_TEXT)) {
+                claimFileTypes.add(Claim.STREAM_TYPE_TEXT);
+            } else if (showTexts != null && !showTexts && claimFileTypes.contains(Claim.STREAM_TYPE_TEXT)) {
+                claimFileTypes.remove(Claim.STREAM_TYPE_TEXT);
             }
         }
         notifyDataSetChanged();
@@ -754,6 +773,8 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         String mediaType;
         boolean isVideo = false;
         boolean isAudio = false;
+        boolean isImage = false;
+        boolean isText = false;
         Claim.GenericMetadata metadata = claim.getValue();
         if (metadata instanceof Claim.StreamMetadata) {
             Claim.StreamMetadata.Source source = ((Claim.StreamMetadata) metadata).getSource();
@@ -761,12 +782,16 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
             if (mediaType != null) {
                 isVideo = mediaType.startsWith(Claim.STREAM_TYPE_VIDEO);
                 isAudio = mediaType.startsWith(Claim.STREAM_TYPE_AUDIO);
+                isImage = mediaType.startsWith(Claim.STREAM_TYPE_IMAGE);
+                isText = mediaType.startsWith(Claim.STREAM_TYPE_TEXT);
             }
         }
         return (Claim.TYPE_COLLECTION.equalsIgnoreCase(claim.getValueType()) && !filterByChannel)
                 || (!filterByFile && !filterByChannel)
-                || (((claimFileTypes.contains(Claim.STREAM_TYPE_VIDEO) && isVideo) || (claimFileTypes.contains(Claim.STREAM_TYPE_AUDIO) && isAudio))
-                     && filterByFile);
+                || (filterByFile && ((claimFileTypes.contains(Claim.STREAM_TYPE_VIDEO) && isVideo)
+                                        || (claimFileTypes.contains(Claim.STREAM_TYPE_AUDIO) && isAudio)
+                                        || (claimFileTypes.contains(Claim.STREAM_TYPE_IMAGE) && isImage)
+                                        || (claimFileTypes.contains(Claim.STREAM_TYPE_TEXT) && isText)));
     }
 
     private void toggleSelectedClaim(Claim claim) {

--- a/app/src/main/java/com/odysee/app/callable/Search.java
+++ b/app/src/main/java/com/odysee/app/callable/Search.java
@@ -17,6 +17,6 @@ public class Search implements Callable<List<Claim>> {
 
     @Override
     public List<Claim> call() throws Exception {
-        return Helper.filterInvalidReposts(Lbry.claimSearch(options, Lbry.API_CONNECTION_STRING));
+        return Helper.filterInvalidReposts(Lbry.claimSearch(options, Lbry.API_CONNECTION_STRING).getClaims());
     }
 }

--- a/app/src/main/java/com/odysee/app/model/Claim.java
+++ b/app/src/main/java/com/odysee/app/model/Claim.java
@@ -40,9 +40,10 @@ public class Claim {
     public static final String TYPE_REPOST = "repost";
     public static final String TYPE_COLLECTION = "collection";
 
+    public static final String STREAM_TYPE_VIDEO = "video";
     public static final String STREAM_TYPE_AUDIO = "audio";
     public static final String STREAM_TYPE_IMAGE = "image";
-    public static final String STREAM_TYPE_VIDEO = "video";
+    public static final String STREAM_TYPE_TEXT = "text";
     public static final String STREAM_TYPE_SOFTWARE = "software";
 
     public static final String ORDER_BY_EFFECTIVE_AMOUNT = "effective_amount";

--- a/app/src/main/java/com/odysee/app/model/ClaimSearchCacheValue.java
+++ b/app/src/main/java/com/odysee/app/model/ClaimSearchCacheValue.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 
 public class ClaimSearchCacheValue {
     @Getter
-    private final List<Claim> claims;
+    private final Page claimsPage;
     @Getter
     private final long timestamp;
 
-    public ClaimSearchCacheValue(List<Claim> claims, long timestamp) {
-        this.claims = new ArrayList<>(claims);
+    public ClaimSearchCacheValue(Page claimsPage, long timestamp) {
+        this.claimsPage = claimsPage;
         this.timestamp = timestamp;
     }
 

--- a/app/src/main/java/com/odysee/app/model/Page.java
+++ b/app/src/main/java/com/odysee/app/model/Page.java
@@ -1,0 +1,20 @@
+package com.odysee.app.model;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+
+public class Page {
+    @Getter
+    private final List<Claim> claims;
+    @Getter
+    private final boolean isLastPage;
+
+    public Page(List<Claim> claims, boolean isLastPage) {
+        this.claims = claims;
+        this.isLastPage = isLastPage;
+    }
+}

--- a/app/src/main/java/com/odysee/app/tasks/claim/ClaimSearchTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/claim/ClaimSearchTask.java
@@ -8,10 +8,11 @@ import java.util.Map;
 
 import com.odysee.app.exceptions.ApiCallException;
 import com.odysee.app.model.Claim;
+import com.odysee.app.model.Page;
 import com.odysee.app.utils.Helper;
 import com.odysee.app.utils.Lbry;
 
-public class ClaimSearchTask extends AsyncTask<Void, Void, List<Claim>> {
+public class ClaimSearchTask extends AsyncTask<Void, Void, Page> {
     private final Map<String, Object> options;
     private final String connectionString;
     private final ClaimSearchResultHandler handler;
@@ -24,10 +25,12 @@ public class ClaimSearchTask extends AsyncTask<Void, Void, List<Claim>> {
         this.progressView = progressView;
         this.handler = handler;
     }
+    @Override
     protected void onPreExecute() {
         Helper.setViewVisibility(progressView, View.VISIBLE);
     }
-    protected List<Claim> doInBackground(Void... params) {
+    @Override
+    protected Page doInBackground(Void... params) {
         try {
             return Lbry.claimSearch(options, connectionString);
         } catch (ApiCallException ex) {
@@ -35,11 +38,12 @@ public class ClaimSearchTask extends AsyncTask<Void, Void, List<Claim>> {
             return null;
         }
     }
-    protected void onPostExecute(List<Claim> claims) {
+    @Override
+    protected void onPostExecute(Page claimsPage) {
         Helper.setViewVisibility(progressView, View.INVISIBLE);
         if (handler != null) {
-            if (claims != null) {
-                handler.onSuccess(Helper.filterInvalidReposts(claims), claims.size() < Helper.parseInt(options.get("page_size"), 0));
+            if (claimsPage != null) {
+                handler.onSuccess(Helper.filterInvalidReposts(claimsPage.getClaims()), claimsPage.isLastPage());
             } else {
                 handler.onError(error);
             }

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
@@ -280,7 +280,7 @@ public class ChannelContentFragment extends Fragment implements DownloadActionLi
 
         Collection<Callable<List<Claim>>> callables = new ArrayList<>(2);
         callables.add(() -> findActiveStream());
-        callables.add(() -> Lbry.claimSearch(claimSearchOptions, Lbry.API_CONNECTION_STRING));
+        callables.add(() -> Lbry.claimSearch(claimSearchOptions, Lbry.API_CONNECTION_STRING).getClaims());
 
         getLoadingView().setVisibility(View.VISIBLE);
         Thread t = new Thread(new Runnable() {

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -661,7 +661,7 @@ public class FollowingFragment extends BaseFragment implements
 
         Collection<Callable<List<Claim>>> callables = new ArrayList<>(2);
         callables.add(() -> fetchActiveLivestreams());
-        callables.add(() -> Lbry.claimSearch(claimSearchOptions, Lbry.API_CONNECTION_STRING));
+        callables.add(() -> Lbry.claimSearch(claimSearchOptions, Lbry.API_CONNECTION_STRING).getClaims());
 
         Thread t = new Thread(new Runnable() {
             @Override

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -114,7 +114,7 @@ public class FollowingFragment extends BaseFragment implements
     private final List<Integer> queuedSuggestedPages = new ArrayList<>();
 
     private int currentSuggestedPage = 0;
-    private int currentClaimSearchPage;
+    private int currentClaimSearchPage = 1;
     private boolean suggestedHasReachedEnd;
     private boolean contentHasReachedEnd;
     private boolean contentPendingFetch = false;
@@ -489,7 +489,7 @@ public class FollowingFragment extends BaseFragment implements
                 contentReleaseTime,
                 0,
                 0,
-                currentClaimSearchPage == 0 ? 1 : currentClaimSearchPage,
+                currentClaimSearchPage,
                 Helper.CONTENT_PAGE_SIZE);
     }
 

--- a/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
@@ -112,7 +112,9 @@ public class SearchFragment extends BaseFragment implements
                     root.findViewById(R.id.file_type_label).setVisibility(View.VISIBLE);
                     root.findViewById(R.id.publish_time_filter_label).setVisibility(View.VISIBLE);
                     root.findViewById(R.id.time_filter_spinner).setVisibility(View.VISIBLE);
-                    root.findViewById(R.id.file_type_filters).setVisibility(View.VISIBLE);
+                    if (((Chip) root.findViewById(R.id.chipSearchFile)).isChecked()) {
+                        root.findViewById(R.id.file_type_filters).setVisibility(View.VISIBLE);
+                    }
                 } else {
                     root.findViewById(R.id.chipgroupFilter).setVisibility(View.GONE);
                     root.findViewById(R.id.file_type_label).setVisibility(View.GONE);

--- a/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
@@ -161,7 +161,7 @@ public class SearchFragment extends BaseFragment implements
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (resultListAdapter != null) {
-                    resultListAdapter.setFileTypeFilters(isChecked, null);
+                    resultListAdapter.setFileTypeFilters(isChecked, null, null, null);
                 }
             }
         });
@@ -169,7 +169,23 @@ public class SearchFragment extends BaseFragment implements
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (resultListAdapter != null) {
-                    resultListAdapter.setFileTypeFilters(null, isChecked);
+                    resultListAdapter.setFileTypeFilters(null, isChecked, null, null);
+                }
+            }
+        });
+        ((CheckBox) root.findViewById(R.id.image_filetype_checkbox)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                if (resultListAdapter != null) {
+                    resultListAdapter.setFileTypeFilters(null, null, isChecked, null);
+                }
+            }
+        });
+        ((CheckBox) root.findViewById(R.id.text_filetype_checkbox)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                if (resultListAdapter != null) {
+                    resultListAdapter.setFileTypeFilters(null, null, null, isChecked);
                 }
             }
         });

--- a/app/src/main/java/com/odysee/app/utils/Lbry.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbry.java
@@ -512,14 +512,16 @@ public final class Lbry {
                     String claimValueType = claim.getValueType();
                     String claimMediaType = claim.getMediaType();
 
-                    // Using Java Stream API to make it easier to add new future claim types
+                    // Using Java Stream API to make it easier to add new future claim types/media types
                     List<String> claimTypes = Stream.of(Claim.TYPE_COLLECTION, Claim.TYPE_REPOST, Claim.TYPE_CHANNEL)
                                                     .collect(Collectors.toList());
+                    Stream<String> mediaTypes = Stream.of("video", "audio", "image", "text");
 
-                    // For now, only claims which are audio, videos, playlists or already/scheduled livestreaming now can be viewed
+                    // For now, only claims which are video, audio, images, text, playlists
+                    // or already/scheduled livestreaming now can be viewed
                     if (claimTypes.contains(claimValueType.toLowerCase())
                             || !claim.hasSource()
-                            || (claim.hasSource() && (claimMediaType.contains("video") || claimMediaType.contains("audio")))) {
+                            || (claim.hasSource() && mediaTypes.anyMatch(claimMediaType::contains))) {
                         claims.add(claim);
                     }
 

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -83,25 +83,50 @@
                                                        android:checkable="true"
                                                        android:text="@string/search_filter_type_channel_label"/>
             </com.google.android.material.chip.ChipGroup>
-            <LinearLayout android:id="@+id/file_type_filters"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:orientation="horizontal"
-                          android:visibility="gone"
-                          app:layout_constraintStart_toStartOf="@id/chipgroupFilter"
-                          app:layout_constraintTop_toBottomOf="@id/chipgroupFilter"
-                          tools:visibility="visible">
-                <CheckBox android:id="@+id/video_filetype_checkbox"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:checked="true"
-                          android:text="@string/search_filter_filetype_video"/>
-                <CheckBox android:id="@+id/audio_filetype_checkbox"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:checked="true"
-                          android:text="@string/search_filter_filetype_audio"/>
-            </LinearLayout>
+
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical" />
+            </HorizontalScrollView>
+
+            <HorizontalScrollView android:id="@+id/file_type_filters"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="@id/chipgroupFilter"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/chipgroupFilter"
+                tools:visibility="visible">
+                <LinearLayout android:layout_width="wrap_content"
+                              android:layout_height="wrap_content"
+                              android:orientation="horizontal">
+                    <CheckBox android:id="@+id/video_filetype_checkbox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="@string/search_filter_filetype_video"/>
+                    <CheckBox android:id="@+id/audio_filetype_checkbox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="@string/search_filter_filetype_audio"/>
+                    <CheckBox android:id="@+id/image_filetype_checkbox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="@string/search_filter_filetype_image"/>
+                    <CheckBox android:id="@+id/text_filetype_checkbox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:text="@string/search_filter_filetype_text"/>
+                </LinearLayout>
+            </HorizontalScrollView>
 
             <androidx.appcompat.widget.AppCompatSpinner android:id="@+id/time_filter_spinner"
                                                         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -403,6 +403,8 @@
     <string name="search_filter_type_channel_label">Channel</string>
     <string name="search_filter_filetype_video">Video</string>
     <string name="search_filter_filetype_audio">Audio</string>
+    <string name="search_filter_filetype_image">Image</string>
+    <string name="search_filter_filetype_text">Text</string>
     <string-array name="publish_timeframe_filter">
         <item>Anytime</item>
         <item>Last 24 hours</item>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## Fixes

Fix: #186 

## Changes made

### Use `total_pages` for checking if end reached in claim search

Fix a bug where `hasReachedEnd` was incorrectly set because the claims
array was smaller than `page_size` due to filtering.

### Following: Start search page at 1

LBRY page index starts at 1, there is no result at page 0.

### Search: When filter opened, only show type picker if file chip selected

### Display markdown posts and images

- Use org.commonmark dependency and add extensions dependencies.
- Allow filtering for images and text in search.
- Put search file type list in scroll view.