### PR TITLE
Increase timeout amount for Lighthouse search queries

### DIFF
--- a/app/src/main/java/com/odysee/app/utils/Lighthouse.java
+++ b/app/src/main/java/com/odysee/app/utils/Lighthouse.java
@@ -92,7 +92,8 @@ public class Lighthouse {
 
             return results;
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
+            return null;
         }
     }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Lighthouse is failing with timeouts errors when loading related content. Query is not being url-encoded
## What is the new behavior?
After increasing the timeout value, no error happens or is logged. query is now being url-encoded