### PR TITLE
Use smooth scrolling when adding new chat messages on livestreams

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -4885,7 +4885,9 @@ public class FileViewFragment extends BaseFragment implements
                                                         ses.schedule(new Runnable() {
                                                             @Override
                                                             public void run() {
-                                                                chatMessageList.smoothScrollToPosition(chatMessageListAdapter.getItemCount() - 1);
+                                                                if (chatMessageListAdapter.getItemCount() > 0) {
+                                                                    chatMessageList.smoothScrollToPosition(chatMessageListAdapter.getItemCount() - 1);
+                                                                }
                                                             }
                                                         }, 100, TimeUnit.MILLISECONDS);
                                                     }

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -4881,12 +4881,13 @@ public class FileViewFragment extends BaseFragment implements
                                                         chatMessageList.setAdapter(chatMessageListAdapter);
                                                     } else {
                                                         chatMessageListAdapter.addMessage(comment);
-                                                        new Handler(Looper.myLooper()).postDelayed(new Runnable() {
+                                                        ScheduledExecutorService ses = Executors.newSingleThreadScheduledExecutor();
+                                                        ses.schedule(new Runnable() {
                                                             @Override
                                                             public void run() {
-                                                                chatMessageList.scrollToPosition(chatMessageListAdapter.getItemCount() - 1);
+                                                                chatMessageList.smoothScrollToPosition(chatMessageListAdapter.getItemCount() - 1);
                                                             }
-                                                        }, 100);
+                                                        }, 100, TimeUnit.MILLISECONDS);
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Chat doesn't scroll when new items are added
## What is the new behavior?
Chat is always showing last fetched chat message
## Other information
Handler wasn't working, so I replaced it with a scheduled executor which is only run a single time.
