### PR TITLE
Always play media as non-transcoded while we can't figure out if it really is

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2318,7 +2318,9 @@ public class FileViewFragment extends BaseFragment implements
                 try (Response response = client.newCall(request).execute()) {
                     String contentType = response.header("Content-Type");
                     if (contentType != null) {
-                        MainActivity.videoIsTranscoded = contentType.equals("application/vnd.apple.mpegurl") || contentType.equals("audio/mpegurl"); // HLS
+//                        MainActivity.videoIsTranscoded = contentType.equals("application/vnd.apple.mpegurl") || contentType.equals("audio/mpegurl"); // HLS
+                        // Content-Type is not reliable enough for this use case, so let's always use a non-transcoded media-source for now
+                        MainActivity.videoIsTranscoded = false;
                     }
                 } catch (Exception ex) {
                     ex.printStackTrace();


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Server is returning "application/x-mpegurl" even if media has not being transcoded. That causes app to not be able to play it
## What is the new behavior?
App will always play media but not allow user to change its quality