### PR TITLE
Show appropriate UI when a claim is for a non-live livestream

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -1462,17 +1462,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         if (claim.getLivestreamUrl() != null) {
             params.put("livestreamUrl", claim.getLivestreamUrl());
         }
+        params.put("claim", claim);
         openFragment(FileViewFragment.class, true, params);
     }
 
     /**
-     * @deprecated Use openRewards(null) instead
+     *
+     * @param params Can be null if you don't want to pass any parameters
      */
-    @Deprecated
-    public void openRewards() {
-        openRewards(null);
-    }
-
     public void openRewards(@Nullable Map<String, Object> params) {
         if (params != null && params.containsKey("source") ) {
             String sourceParam = (String) params.get("source");

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -537,7 +537,7 @@ public class FileViewFragment extends BaseFragment implements
 
     private void updatePlaylistContentDisplay(int index) {
         if (playlistClaims != null) {
-            String value = getString(R.string.playlist_position_tracker, currentPlaylistTitle, index + 1, playlistClaims.size());
+            String value = getString(R.string.playlist_position_tracker, currentPlaylistTitle, String.valueOf(index + 1), String.valueOf(playlistClaims.size()));
             Helper.setViewText(relatedContentTitle, value);
         }
     }
@@ -556,7 +556,6 @@ public class FileViewFragment extends BaseFragment implements
                     return;
                 }
 
-
                 if (params.containsKey("claim")) {
                     newClaim = (Claim) params.get("claim");
                     // Only update fragment if new claim is different from currently being played
@@ -566,30 +565,33 @@ public class FileViewFragment extends BaseFragment implements
                 }
 
                 if (params.containsKey("url")) {
-                    LbryUri newLbryUri = LbryUri.tryParse(params.get("url").toString());
-                    if (newLbryUri != null) {
-                        newUrl = newLbryUri.toString();
-                        String qs = newLbryUri.getQueryString();
-                        if (!Helper.isNullOrEmpty(qs)) {
-                            String[] qsPairs = qs.split("&");
-                            for (String pair : qsPairs) {
-                                String[] parts = pair.split("=");
-                                if (parts.length < 2) {
-                                    continue;
-                                }
-                                if ("comment_hash".equalsIgnoreCase(parts[0])) {
-                                    commentHash = parts[1];
-                                    break;
+                    Object urlParam = params.get("url");
+                    if (urlParam != null) {
+                        LbryUri newLbryUri = LbryUri.tryParse(urlParam.toString());
+                        if (newLbryUri != null) {
+                            newUrl = newLbryUri.toString();
+                            String qs = newLbryUri.getQueryString();
+                            if (!Helper.isNullOrEmpty(qs)) {
+                                String[] qsPairs = qs.split("&");
+                                for (String pair : qsPairs) {
+                                    String[] parts = pair.split("=");
+                                    if (parts.length < 2) {
+                                        continue;
+                                    }
+                                    if ("comment_hash".equalsIgnoreCase(parts[0])) {
+                                        commentHash = parts[1];
+                                        break;
+                                    }
                                 }
                             }
-                        }
 
-                        if (fileClaim == null || !newUrl.equalsIgnoreCase(currentUrl)) {
-                            updateRequired = true;
+                            if (fileClaim == null || !newUrl.equalsIgnoreCase(currentUrl)) {
+                                updateRequired = true;
+                            }
                         }
                     }
                 }
-                if (params.containsKey("livestreamUrl")) {
+                if (params.containsKey("livestreamUrl") && params.get("livestreamUrl") != null) {
                     claimLivestreamUrl = (String) params.get("livestreamUrl");
                 }
             } else if (currentUrl != null) {
@@ -1884,12 +1886,32 @@ public class FileViewFragment extends BaseFragment implements
             return;
         }
         if (!claimToRender.hasSource()) {
-            // TODO See if the "publisher is not live yet" UI must be shown
+            Context context = getContext();
+            View root = getView();
+            if (claimToRender.getThumbnailUrl() != null && context != null && root != null && !claimToRender.isLive()) {
+                String urlResult = getLivestreamUrl();
+                if (urlResult != null && urlResult.equalsIgnoreCase("notlive")) {
+                    root.findViewById(R.id.file_view_livestream_not_live).setVisibility(View.VISIBLE);
+                    root.findViewById(R.id.file_view_exoplayer_container).setVisibility(View.GONE);
+                    TextView userNotStreaming = root.findViewById(R.id.user_not_streaming);
+                    userNotStreaming.setText(context.getString(R.string.user_not_live_yet, claimToRender.getPublisherName()));
+                    userNotStreaming.setVisibility(View.VISIBLE);
+                    ImageView thumbnailView = root.findViewById(R.id.file_view_livestream_thumbnail);
+                    Glide.with(context.getApplicationContext()).
+                            asBitmap().
+                            load(claimToRender.getThumbnailUrl()).
+                            into(thumbnailView);
+                } else {
+                    fileClaim.setLive(true);
+                    fileClaim.setLivestreamUrl(urlResult);
+                }
+            }
 
             // livestream, so we load up the messages and initialise the websocket
             initLivestreamChat();
         }
-        if (claimToRender.isPlayable() && MainActivity.appPlayer != null) {
+        if (claimToRender.isPlayable() && MainActivity.appPlayer != null
+                && ((!claimToRender.isLive() && claimLivestreamUrl == null) || (claimToRender.isLive() && claimToRender.getLivestreamUrl() != null))) {
             MainActivity.appPlayer.setPlayWhenReady(isPlaying);
         }
 
@@ -1985,7 +2007,7 @@ public class FileViewFragment extends BaseFragment implements
             root.findViewById(R.id.file_view_media_meta_container).setVisibility(View.VISIBLE);
 
             Claim.GenericMetadata metadata = claimToRender.getValue();
-            if (!Helper.isNullOrEmpty(claimToRender.getThumbnailUrl())) {
+            if (!Helper.isNullOrEmpty(claimToRender.getThumbnailUrl()) && context != null) {
                 ImageView thumbnailView = root.findViewById(R.id.file_view_thumbnail);
                 Glide.with(context.getApplicationContext()).asBitmap().load(
                         claimToRender.getThumbnailUrl(context.getResources().getDisplayMetrics().widthPixels, thumbnailView.getLayoutParams().height, 85)).centerCrop().into(thumbnailView);
@@ -2283,6 +2305,7 @@ public class FileViewFragment extends BaseFragment implements
                             }
 
                             root.findViewById(R.id.file_view_livestream_not_live).setVisibility(View.VISIBLE);
+                            root.findViewById(R.id.file_view_exoplayer_container).setVisibility(View.GONE);
                             TextView userNotStreaming = root.findViewById(R.id.user_not_streaming);
                             userNotStreaming.setText(getString(R.string.user_not_live_yet, claimToPlay.getPublisherName()));
                             userNotStreaming.setVisibility(View.VISIBLE);
@@ -2306,25 +2329,28 @@ public class FileViewFragment extends BaseFragment implements
                 Map<String, Object> params = new HashMap<>();
                 params.put("uri", theClaim.getPermanentUrl());
                 JSONObject result = (JSONObject) Lbry.parseResponse(Lbry.apiCall(Lbry.METHOD_GET, params));
-                String sourceUrl = (String) result.get("streaming_url");
-                currentMediaSourceUrl = sourceUrl;
+                if (result != null) {
+                    String sourceUrl = (String) result.get("streaming_url");
+                    currentMediaSourceUrl = sourceUrl;
 
-                // Get the stream type
-                OkHttpClient client = new OkHttpClient();
-                Request request = new Request.Builder()
-                        .url(sourceUrl)
-                        .head()
-                        .build();
-                try (Response response = client.newCall(request).execute()) {
-                    String contentType = response.header("Content-Type");
-                    if (contentType != null) {
-                        MainActivity.videoIsTranscoded = contentType.equals("application/vnd.apple.mpegurl") || contentType.equals("audio/mpegurl"); // HLS
+                    // Get the stream type
+                    OkHttpClient client = new OkHttpClient();
+                    Request request = new Request.Builder()
+                            .url(sourceUrl)
+                            .head()
+                            .build();
+                    try (Response response = client.newCall(request).execute()) {
+                        String contentType = response.header("Content-Type");
+                        if (contentType != null) {
+                            Log.i(TAG, "getStreamingUrlAndInitializePlayer: Playing media with Content-Type ".concat(contentType));
+                            MainActivity.videoIsTranscoded = contentType.equals("application/vnd.apple.mpegurl") || contentType.equals("audio/mpegurl"); // HLS
+                        }
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
                     }
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                }
 
-                new Handler(Looper.getMainLooper()).post(() -> initializePlayer(sourceUrl));
+                    new Handler(Looper.getMainLooper()).post(() -> initializePlayer(sourceUrl));
+                }
             } catch (LbryRequestException | LbryResponseException | JSONException ex) {
                 // TODO: How does error handling work here
                 ex.printStackTrace();
@@ -2387,26 +2413,16 @@ public class FileViewFragment extends BaseFragment implements
     }
 
     @AnyThread
-    @Nullable
+    @NonNull
     private String getLivestreamUrl(JSONObject jsonData) {
         try {
-            if (jsonData != null && jsonData.has("live")) {
-                if (jsonData.getBoolean("live") && jsonData.has("url")) {
-                    return jsonData.getString("url");
-                } else {
-                    return "notlive";
-                }
-            } else if (jsonData != null && jsonData.has("Live")) {
-                if (jsonData.getBoolean("Live") && jsonData.has("VideoURL")) {
-                    return jsonData.getString("VideoURL");
-                } else {
-                    return "notlive";
-                }
+            if (jsonData != null && jsonData.has("Live") && jsonData.getBoolean("Live") && jsonData.has("VideoURL")) {
+                return jsonData.getString("VideoURL");
             }
         } catch (JSONException e) {
             e.printStackTrace();
         }
-        return null;
+        return "notlive";
     }
 
     private void setCurrentPlayer(Player currentPlayer) {
@@ -2632,7 +2648,7 @@ public class FileViewFragment extends BaseFragment implements
                                 @Override
                                 public void run() {
                                     try {
-                                        String displayText = getResources().getString(R.string.livestream_view_count, count);
+                                        String displayText = getResources().getString(R.string.livestream_view_count, String.valueOf(count));
                                         View root = getView();
                                         if (root != null) {
                                             TextView textViewCount = root.findViewById(R.id.file_view_view_count);

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -1482,6 +1482,7 @@ public class FileViewFragment extends BaseFragment implements
                 // check full screen mode
                 if (isInFullscreenMode()) {
                     disableFullScreenMode();
+                    smoothScrollToLastChatMessage(); // If there are no chat messages or claim is not for a livestream, this will do nothing
                 } else {
                     enableFullScreenMode();
                 }
@@ -4901,9 +4902,7 @@ public class FileViewFragment extends BaseFragment implements
                                                         ses.schedule(new Runnable() {
                                                             @Override
                                                             public void run() {
-                                                                if (chatMessageListAdapter.getItemCount() > 0) {
-                                                                    chatMessageList.smoothScrollToPosition(chatMessageListAdapter.getItemCount() - 1);
-                                                                }
+                                                                smoothScrollToLastChatMessage();
                                                             }
                                                         }, 100, TimeUnit.MILLISECONDS);
                                                     }
@@ -4942,6 +4941,15 @@ public class FileViewFragment extends BaseFragment implements
                 }
             };
             webSocketClient.connect();
+        }
+    }
+
+    /**
+     * Scroll the list of chat messages so last received message becomes visible
+     */
+    private void smoothScrollToLastChatMessage() {
+        if (chatMessageListAdapter.getItemCount() > 0) {
+            chatMessageList.smoothScrollToPosition(chatMessageListAdapter.getItemCount() - 1);
         }
     }
 

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -112,11 +112,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@color/mediaContainerBackground"
-                android:padding="36dp"
-                android:visibility="gone">
+                android:visibility="gone"
+                tools:visibility="visible">
                 <ImageView android:id="@+id/file_view_livestream_thumbnail"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="match_parent"
                     android:src="@drawable/user_not_live_thumbnail" />
 
             </LinearLayout>
@@ -225,6 +225,10 @@
                 <TextView android:id="@+id/user_not_streaming"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingStart="16dp"
+                    android:paddingEnd="4dp"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
                     android:fontFamily="@font/inter"
                     android:textSize="14sp"
                     android:textColor="?android:attr/textColorPrimary"
@@ -660,9 +664,11 @@
                         android:id="@+id/file_view_publisher_info_area"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:minHeight="48dp"
                         android:layout_toStartOf="@id/file_view_publisher_area_actions"
                         android:background="?attr/selectableItemBackground"
                         android:clickable="true"
+                        android:focusable="true"
                         android:paddingStart="16dp"
                         android:paddingTop="12dp"
                         android:paddingBottom="12dp">
@@ -736,8 +742,10 @@
                             android:id="@+id/file_view_icon_follow"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:minHeight="48dp"
                             android:background="?attr/selectableItemBackground"
                             android:clickable="true"
+                            android:focusable="true"
                             android:orientation="horizontal"
                             android:paddingTop="8dp"
                             android:paddingBottom="8dp">


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## Fixes

Issue Number: #217 

## What is the current behavior?
User gets confused as livestream doesn't seem to start
## What is the new behavior?
User is shown a message that stream is not currently live. User can still read and publish messages on the chat
## Other information
Some nullity checking have been added, mostly to fix lint warnings.

The code for scroll to last chat message has been extracted because when user exits full-screen mode, app is no longer showing last message.

The openRewards() method has been finally removed as it was deprecated some time ago and no code was using it.

The getLivestreamUrl(JSONObject) method has been simplified. The API used to get if a channel had any live-streaming claim changed their key names while in development. That's why code was branching depending on the key being "live" or "Live". Code had to branch because the key to het the url was different on each branch, so just checking for "live" ignoring the case cannot be used. As API has already being made public -I mean, it is in production code-, this method no longer has to branch depending on that key name.

Some lint errors has also been fixed: convert integers to strings when formatting a string resource.

On fragment_file_view.xml, some views have now a minHeight attribute to make it easier to be clicked.