### PR TITLE
Decrease network requests while in Battery Saver mode

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -29,11 +29,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.os.AsyncTask;
-import android.os.Build;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
+import android.os.*;
 import android.provider.MediaStore;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.text.Editable;
@@ -1141,6 +1137,16 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         if (lp.leftMargin != scaledMiniPlayerMargin || lp.rightMargin != scaledMiniPlayerMargin || lp.bottomMargin != scaledMiniPlayerBottomMargin) {
             lp.setMargins(scaledMiniPlayerMargin, 0, scaledMiniPlayerMargin, scaledMiniPlayerBottomMargin);
         }
+    }
+
+    public boolean isBatterySaverMode() {
+        Context ctx = getBaseContext();
+        if (ctx != null) {
+            PowerManager pm = (PowerManager) ctx.getSystemService(Context.POWER_SERVICE);
+
+            return (pm != null && pm.isPowerSaveMode());
+        }
+        return false;
     }
 
     public boolean isBackgroundPlaybackEnabled() {

--- a/app/src/main/java/com/odysee/app/model/Reactions.java
+++ b/app/src/main/java/com/odysee/app/model/Reactions.java
@@ -1,7 +1,6 @@
 package com.odysee.app.model;
 
 import lombok.Data;
-import lombok.Getter;
 
 @Data
 public class Reactions {
@@ -9,6 +8,7 @@ public class Reactions {
     private int othersDislikes;
     private boolean liked;
     private boolean disliked;
+    private long lastUpdateTimestamp = 0L;
 
     public Reactions() { }
     public Reactions(int likes, int dislikes) {

--- a/app/src/main/java/com/odysee/app/ui/wallet/WalletFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/wallet/WalletFragment.java
@@ -559,6 +559,12 @@ public class WalletFragment extends BaseFragment implements WalletBalanceListene
                 return;
             }
 
+            // When device is in Battery Saver mode, the scheduled wallet update will no perform the job.
+            // In order to show user the update balance, let's request it explicitly when user opens the Wallet fragment
+            if (activity.isBatterySaverMode()) {
+                activity.updateWalletBalance();
+            }
+
             activity.syncWalletAndLoadPreferences();
             LbryAnalytics.setCurrentScreen(activity, "Wallet", "Wallet");
         }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?
App will update reactions for a claim and the user wallet balance when Battery Saver mode is enabled
## What is the new behavior?
Neither reactions nor wallet balance is updated when Battery Saver is enabled
## Other information
Scheduled tasks are called but only run if not on Battery Saver mode. This will still run some code, but network connections are more power hungry than the part where Android calls the scheduled runnable.

It can be tested on Pixel devices or most other devices. I tested it on Pixel emulator and a physical Samsung tablet. Some Chinese manufacturers are always returning 'false' when their propietary battery saver is enabled. This is not the standard behaviour. It is possible to check for this, but it must be done with different code for each manufacturer, and, as I said, their returned value is not the one which should have been returned.
