### PR TITLE
Remove redundant information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Odysee Android
 
-<a href="https://github.com/OdyseeTeam/odysee-android/blob/master/LICENSE" title="MIT licensed">
-   <img alt="license" src="https://img.shields.io/github/license/OdyseeTeam/odysee-android?style=for-the-badge">
-</a>
-
-
 ## Build from Source
 To build the app, even as a debug APK, you will need to copy `app/twitter.properties.sample` file as `app/twitter.properties`
 
@@ -39,8 +34,6 @@ Then you will be able to build a signed APK file via Build/Generate Signed Bundl
 
 ## Contributing
 We :heart: contributions from everyone and contributions to this project are encouraged, and compensated. We welcome [bug reports](https://github.com/OdyseeTeam/odysee-android/issues/), [bug fixes](https://github.com/OdyseeTeam/odysee-android/pulls) and feedback is always appreciated.
-
-## [![contributions welcome](https://img.shields.io/github/issues/OdyseeTeam/odysee-android?style=for-the-badge&color=informational)](https://github.com/OdyseeTeam/odysee-android/issues) [![GitHub contributors](https://img.shields.io/github/contributors/OdyseeTeam/odysee-android?style=for-the-badge)](https://gitHub.com/OdyseeTeam/odysee-android/graphs/contributors/)
 
 ## License
 This project is MIT licensed. For the full license, see [LICENSE](LICENSE).


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Documentation changes

## What is the current behavior?
Every user browsing to Odysee Android repository root will see the amount of opened issues and the amount of contributors
## What is the new behavior?
Both informations are no longer shown
## Other information
The amount of opened issues is already shown on the GitHub repository web page. On that page they are also showing the amount of contributors. There is no need to also show it on the README file.

When opening the project on the IDE, README file is shown, which parses it in order to also show images and links. I see it as a privacy problem, as it is signaling GitHub that someone is opening that file IN an application able to display it in a rich way.

README file should help people build the app. Encouraging people to contribute has also its place in this file, like it is already the case. However, any person arriving to this webpage, will also be able to see the amount of opened issues and, if interested, the amount of contributors. That's the first information which is shown to any person visiting the root page of this repository. Adding it to the README file makes it look fancier and more like a webpage but this is not a webpage but a text file.

MIT license snipped has also been removed for privacy concerns. GitHub is already showing the license applied to the source code of the app.
