### PR TITLE
Show Comments tab on Channel fragment

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelFragment.java
@@ -757,7 +757,7 @@ public class ChannelFragment extends BaseFragment implements FetchChannelsListen
 
         @Override
         public int getItemCount() {
-            return 4;
+            return 5;
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Other information
The count of tabs on Channel fragment wasn't updated after adding some new tabs, making the last one to not appear, happening this was the Comments tab.

Merging this directly.
