### PR TITLE
Determine if video is transcoded depending on response headers

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2343,16 +2343,15 @@ public class FileViewFragment extends BaseFragment implements
                             .head()
                             .build();
                     try (Response response = client.newCall(request).execute()) {
-                        String contentType = response.header("Content-Type");
-                        if (contentType != null) {
-                            Log.i(TAG, "getStreamingUrlAndInitializePlayer: Playing media with Content-Type ".concat(contentType));
-                            MainActivity.videoIsTranscoded = contentType.equals("application/vnd.apple.mpegurl") || contentType.equals("audio/mpegurl"); // HLS
-                        }
+                        String requestUrl = response.request().url().toString();
+                        boolean requestRedirected = response.priorResponse() != null && response.priorResponse().isRedirect();
+                        MainActivity.videoIsTranscoded = requestRedirected && response.isSuccessful() && requestUrl.endsWith("m3u8");
+                        currentMediaSourceUrl = MainActivity.videoIsTranscoded ? requestUrl : sourceUrl;
                     } catch (Exception ex) {
                         ex.printStackTrace();
                     }
 
-                    new Handler(Looper.getMainLooper()).post(() -> initializePlayer(sourceUrl));
+                    new Handler(Looper.getMainLooper()).post(() -> initializePlayer(currentMediaSourceUrl));
                 }
             } catch (LbryRequestException | LbryResponseException | JSONException ex) {
                 // TODO: How does error handling work here


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #219

## What is the current behavior?
The current code to determine if video has been transcoded is not reliable enough. Returning true when it wasn't.
## What is the new behavior?
New code determines if video had been transcoded based on the response
## Other information
Determine if video was transcoded allows user to select different resolutions if it ia available as a transcoded stream.
