### PR TITLE
Animation when player minimized/maximized

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -42,6 +42,7 @@ import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextWatcher;
 import android.text.style.TypefaceSpan;
+import android.transition.Slide;
 import android.util.Base64;
 import android.util.Log;
 import android.view.Gravity;
@@ -715,7 +716,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 clearPlayingPlayer();
                 hideNotifications(); // Avoid showing Notifications fragment when clicking Publish when Notification panel is opened
                 fragmentManager.beginTransaction().replace(R.id.main_activity_other_fragment, new PublishFragment(), "PUBLISH").addToBackStack("publish_claim").commit();
-                findViewById(R.id.main_activity_other_fragment).setVisibility(View.VISIBLE);
                 findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);
                 hideActionBar();
             }
@@ -848,10 +848,12 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 showBottomNavigation();
                 switchToolbarForSearch(false);
 
+                /* FIXME (when tablet support): Home screen not shown because File View never hidden (#???)
                 // On tablets, multiple fragments could be visible. Don't show Home Screen when File View is visible
                 if (findViewById(R.id.main_activity_other_fragment).getVisibility() != View.VISIBLE) {
                     findViewById(R.id.fragment_container_main_activity).setVisibility(View.VISIBLE);
-                }
+                }*/
+                findViewById(R.id.fragment_container_main_activity).setVisibility(View.VISIBLE);
 
                 showWalletBalance();
                 findViewById(R.id.fragment_container_search).setVisibility(View.GONE);
@@ -1092,6 +1094,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             public void onClick(View view) {
                 if (nowPlayingClaim != null && !Helper.isNullOrEmpty(nowPlayingClaimUrl)) {
                     hideNotifications();
+                    hideGlobalNowPlaying();
                     openFileUrl(nowPlayingClaimUrl);
                 }
             }
@@ -1514,7 +1517,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     private void renderPictureInPictureMode() {
-        findViewById(R.id.main_activity_other_fragment).setVisibility(View.GONE);
         findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);
         findViewById(R.id.miniplayer).setVisibility(View.GONE);
         findViewById(R.id.appbar).setVisibility(View.GONE);
@@ -1555,7 +1557,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         boolean inChannelView = fragment instanceof ChannelFragment;
         boolean inSearchView = fragment instanceof SearchFragment;
 
-        findViewById(R.id.main_activity_other_fragment).setVisibility(!inMainView ? View.VISIBLE : View.GONE);
         findViewById(R.id.content_main).setVisibility(View.VISIBLE);
 
         findViewById(R.id.fragment_container_main_activity).setVisibility(inMainView ? View.VISIBLE : View.GONE);
@@ -1791,7 +1792,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             if (fragment != null) {
                 updateCurrentDisplayFragment(fragment);
                 hideBottomNavigation();
-                findViewById(R.id.main_activity_other_fragment).setVisibility(View.VISIBLE);
                 findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);
             }
         }
@@ -3364,7 +3364,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     findViewById(R.id.fragment_container_main_activity).setVisibility(View.VISIBLE);
                     showBottomNavigation();
                 }
-                findViewById(R.id.main_activity_other_fragment).setVisibility(View.GONE);
                 findViewById(R.id.toolbar_balance_and_tools_layout).setVisibility(View.VISIBLE);
 
                 ActionBar actionBar = getSupportActionBar();
@@ -4095,6 +4094,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
             FragmentTransaction transaction;
             if (fragment instanceof FileViewFragment) {
+                Slide enterTransition = new Slide(Gravity.BOTTOM);
+                enterTransition.setDuration(this.getResources().getInteger(android.R.integer.config_mediumAnimTime));
+                fragment.setEnterTransition(enterTransition);
                 transaction = manager.beginTransaction().replace(R.id.main_activity_other_fragment, fragment, FILE_VIEW_TAG);
             } else {
                 transaction = manager.beginTransaction().replace(R.id.main_activity_other_fragment, fragment);
@@ -4112,7 +4114,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             transaction.commit();
 
             currentDisplayFragment = fragment;
-            findViewById(R.id.main_activity_other_fragment).setVisibility(View.VISIBLE);
             findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);
             findViewById(R.id.bottom_navigation).setVisibility(View.GONE);
             findViewById(R.id.toolbar_balance_and_tools_layout).setVisibility(View.GONE);

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -221,6 +221,7 @@ import com.odysee.app.utils.LbryUri;
 import com.odysee.app.utils.Lbryio;
 import com.odysee.app.utils.Predefined;
 import com.odysee.app.checkers.CommentEnabledCheck;
+import com.odysee.app.views.MediaRelativeLayout;
 
 import javax.net.ssl.SSLParameters;
 
@@ -1436,6 +1437,7 @@ public class FileViewFragment extends BaseFragment implements
             }
         });
 
+        MediaRelativeLayout mediaContainer = root.findViewById(R.id.file_view_media_container);
         PlayerView playerView = root.findViewById(R.id.file_view_exoplayer_view);
         View playbackSpeedContainer = playerView.findViewById(R.id.player_playback_speed);
         TextView textPlaybackSpeed = playerView.findViewById(R.id.player_playback_speed_label);
@@ -1624,7 +1626,7 @@ public class FileViewFragment extends BaseFragment implements
         relatedContentList.setLayoutManager(relatedContentListLLM);
         commentsList.setLayoutManager(commentsListLLM);
 
-        GestureDetector.SimpleOnGestureListener gestureListener = new GestureDetector.SimpleOnGestureListener() {
+        GestureDetector.SimpleOnGestureListener playerGestureListener = new GestureDetector.SimpleOnGestureListener() {
             @Override
             public boolean onDoubleTap(MotionEvent e) {
                 ImageView seekOverlay = root.findViewById(R.id.seek_overlay);
@@ -1671,11 +1673,26 @@ public class FileViewFragment extends BaseFragment implements
                 return true;
             }
         };
-        GestureDetector detector = new GestureDetector(getContext(), gestureListener);
+        GestureDetector playerGestureDetector = new GestureDetector(getContext(), playerGestureListener);
         playerView.setOnTouchListener((view, motionEvent) -> {
-            detector.onTouchEvent(motionEvent);
+            playerGestureDetector.onTouchEvent(motionEvent);
             return true;
         });
+
+        GestureDetector.SimpleOnGestureListener mediaContainerGestureListener = new GestureDetector.SimpleOnGestureListener() {
+            @Override
+            public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+                if (velocityY > 0) {
+                    Context context = getContext();
+                    if (context instanceof MainActivity) {
+                        MainActivity activity = (MainActivity) context;
+                        activity.onBackPressed();
+                    }
+                }
+                return true;
+            }
+        };
+        mediaContainer.gestureDetector = new GestureDetector(getContext(), mediaContainerGestureListener);
     }
 
     private void finishChatSend(boolean clearInput) {

--- a/app/src/main/java/com/odysee/app/views/MediaRelativeLayout.java
+++ b/app/src/main/java/com/odysee/app/views/MediaRelativeLayout.java
@@ -1,0 +1,23 @@
+package com.odysee.app.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+import android.widget.RelativeLayout;
+
+public class MediaRelativeLayout extends RelativeLayout {
+    public GestureDetector gestureDetector;
+
+    public MediaRelativeLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        if (gestureDetector != null) {
+            return gestureDetector.onTouchEvent(ev);
+        }
+        return false;
+    }
+}

--- a/app/src/main/res/anim/slide_in_bottom.xml
+++ b/app/src/main/res/anim/slide_in_bottom.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromYDelta="50%p"
+    android:toYDelta="0"
+    android:duration="@android:integer/config_mediumAnimTime" />

--- a/app/src/main/res/anim/slide_out_bottom.xml
+++ b/app/src/main/res/anim/slide_out_bottom.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromYDelta="0"
+    android:toYDelta="50%p"
+    android:duration="@android:integer/config_mediumAnimTime" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,25 +16,26 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <FrameLayout
-            android:id="@+id/main_activity_other_fragment"
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"
-            android:visibility="gone"/>
+            android:layout_weight="1">
+            <FrameLayout
+                android:id="@+id/fragment_container_main_activity"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
 
-        <FrameLayout
-            android:id="@+id/fragment_container_main_activity"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"/>
+            <FrameLayout
+                android:id="@+id/fragment_container_search"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone" />
 
-        <FrameLayout
-            android:id="@+id/fragment_container_search"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:visibility="gone"/>
+            <FrameLayout
+                android:id="@+id/main_activity_other_fragment"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </RelativeLayout>
 
         <RelativeLayout
             android:id="@+id/notifications_container"

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -5,7 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/file_view_global_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground">
     <RelativeLayout
         android:id="@+id/file_view_loading_state"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -42,7 +42,7 @@
         android:orientation="vertical"
         android:visibility="visible">
 
-        <RelativeLayout
+        <com.odysee.app.views.MediaRelativeLayout
             android:id="@+id/file_view_media_container"
             android:layout_width="match_parent"
             android:layout_height="246dp"
@@ -205,7 +205,7 @@
                         android:textSize="14sp" />
                 </LinearLayout>
             </RelativeLayout>
-        </RelativeLayout>
+        </com.odysee.app.views.MediaRelativeLayout>
 
         <androidx.core.widget.NestedScrollView
             android:id="@+id/file_view_scroll_view"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #17

## What is the current behavior?

Quick snapping to/from the file view fragment.

## What is the new behavior?

Smooth slide in/out.

## Commit messages

### Animation when player minimized/maximized

- Keep main_activity_other_fragment always visible so fragment is still
  visible during transaction. This is fine as the fragment is removed at
  the end of the transaction.
- Vertically stack fragment containers so main_activity_other_fragment
  can be left visible. The main_activity_other_fragment container is
  placed top-most so the animation is always visible.
- Use ?android:attr/colorBackground in FileViewFragment so it is not
  transparent during the exit transition.

### File View: Detect downwards fling to dismiss