### PR TITLE
Following notifications: default off, show confirm change alert

### DIFF
--- a/app/src/main/java/com/odysee/app/model/lbryinc/Subscription.java
+++ b/app/src/main/java/com/odysee/app/model/lbryinc/Subscription.java
@@ -33,7 +33,7 @@ public class Subscription {
         if (lbryUri != null)
             u = lbryUri.toString();
 
-        return new Subscription(claim.getName(), u, false);
+        return new Subscription(claim.getName(), u, true);
     }
     public String toString() {
         return url;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,8 @@
     <string name="playlists">Playlists</string>
     <string name="website">Website</string>
     <string name="reposted">reposted</string>
+    <string name="confirm_turn_on_notifications">Turn on notifications?</string>
+    <string name="confirm_turn_off_notifications">Turn off notifications?</string>
     <string name="receive_all_notifications">You will receive all notifications</string>
     <string name="receive_no_notifications">You will not receive notifications for this channel</string>
     <string name="confirm_unfollow">Stop following channel?</string>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #232 (`notifications when following should not be turned on by default. confirm action on bell icon (turn on / off notifications)`)

## What is the current behavior?

Notifications are enabled by default when following a channel.

No confirmation when enabling/disabling channel notifications, only info message after.

## What is the new behavior?

Notifications are disabled by default when following a channel.

Confirmation before enabling/disabling channel notifications.
