### PR TITLE
Fix dark mode icon color in Library

### DIFF
--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -77,7 +77,8 @@
                         android:layout_height="24dp"
                         android:layout_centerVertical="true"
                         android:src="@drawable/ic_history"
-                        android:layout_marginStart="16dp"/>
+                        android:layout_marginStart="16dp"
+                        app:tint="?android:attr/textColorPrimary" />
                     <TextView
                         android:layout_toEndOf="@id/icon_library_item_history"
                         android:layout_width="wrap_content"
@@ -106,7 +107,8 @@
                         android:layout_height="24dp"
                         android:layout_centerVertical="true"
                         android:src="@drawable/ic_favorites"
-                        android:layout_marginStart="16dp"/>
+                        android:layout_marginStart="16dp"
+                        app:tint="?android:attr/textColorPrimary" />
                     <TextView
                         android:layout_toEndOf="@id/icon_library_item_favorites"
                         android:layout_width="wrap_content"
@@ -135,7 +137,8 @@
                         android:layout_height="24dp"
                         android:layout_centerVertical="true"
                         android:src="@drawable/ic_watch_later"
-                        android:layout_marginStart="16dp"/>
+                        android:layout_marginStart="16dp"
+                        app:tint="?android:attr/textColorPrimary" />
                     <TextView
                         android:layout_toEndOf="@id/icon_library_item_watchlater"
                         android:layout_width="wrap_content"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Icon color is too dark when in dark mode

## What is the new behavior?

Use `?android:attr/textColorPrimary` for icon tint.
