### PR TITLE
Channel content: Set contentHasReachedEnd based on Page isLastPage

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
@@ -42,6 +42,7 @@ import com.odysee.app.dialog.ContentSortDialogFragment;
 import com.odysee.app.listener.DownloadActionListener;
 import com.odysee.app.model.Claim;
 import com.odysee.app.model.LbryFile;
+import com.odysee.app.model.Page;
 import com.odysee.app.utils.Helper;
 import com.odysee.app.utils.Lbry;
 import com.odysee.app.utils.Predefined;
@@ -278,27 +279,36 @@ public class ChannelContentFragment extends Fragment implements DownloadActionLi
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
-        Collection<Callable<List<Claim>>> callables = new ArrayList<>(2);
-        callables.add(() -> findActiveStream());
-        callables.add(() -> Lbry.claimSearch(claimSearchOptions, Lbry.API_CONNECTION_STRING).getClaims());
+        Collection<Callable<Page>> callables = new ArrayList<>(2);
+        callables.add(() -> new Page(findActiveStream(), true /* ignored */));
+        callables.add(() -> Lbry.claimSearch(claimSearchOptions, Lbry.API_CONNECTION_STRING));
 
         getLoadingView().setVisibility(View.VISIBLE);
         Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
                 try {
-                    List<Future<List<Claim>>> results = executor.invokeAll(callables);
+                    List<Future<Page>> results = executor.invokeAll(callables);
 
                     List<Claim> items = new ArrayList<>();
 
-                    for (Future<List<Claim>> f : results) {
-                        if (!f.isCancelled()) {
-                            List<Claim> internalItems = f.get();
-
-                            if (internalItems != null) {
-                                items.addAll(internalItems);
-                            }
+                    Future<Page> activeStreamFuture = results.get(0);
+                    Page activeStreamPage = activeStreamFuture.get();
+                    if (activeStreamPage != null) {
+                        List<Claim> activeStream = activeStreamPage.getClaims();
+                        if (activeStream != null) {
+                            items.addAll(activeStream);
                         }
+                    }
+
+                    Future<Page> claimSearchFuture = results.get(1);
+                    Page claimSearchPage = claimSearchFuture.get();
+                    boolean hasReachedEnd;
+                    if (claimSearchPage != null) {
+                        items.addAll(claimSearchPage.getClaims());
+                        hasReachedEnd = claimSearchPage.isLastPage();
+                    } else {
+                        hasReachedEnd = true;
                     }
 
                     executor.shutdown();
@@ -360,7 +370,7 @@ public class ChannelContentFragment extends Fragment implements DownloadActionLi
                                     contentList.setAdapter(contentListAdapter);
                                 }
 
-                                contentHasReachedEnd = true;
+                                contentHasReachedEnd = hasReachedEnd;
                                 contentClaimSearchLoading = false;
                                 checkNoContent();
                             }


### PR DESCRIPTION


## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Refactoring (no functional changes)

## Fixes

Issue Number: #232 (`can't infinite scroll to more pages on channel page`)

## What is the current behavior?

Channel content list stops after first 25 claims (or less if some are filtered).

## What is the new behavior?

At end of channel content list next page is loaded.

## Other information

- Refactor claim list callables to return Page
- Individually parse result of each callable to get isLastPage value
  from last callable (claim search).