### PR TITLE
Fix global player not expanding to full content when clicked

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -1098,10 +1098,18 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         findViewById(R.id.global_now_playing_card).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (nowPlayingClaim != null && !Helper.isNullOrEmpty(nowPlayingClaimUrl)) {
+                if (nowPlayingClaim != null && (!Helper.isNullOrEmpty(nowPlayingClaimUrl) || !Helper.isNullOrEmpty(nowPlayingClaim.getCanonicalUrl()))) {
                     hideNotifications();
                     hideGlobalNowPlaying();
-                    openFileUrl(nowPlayingClaimUrl);
+
+                    String urlParam;
+
+                    if (!Helper.isNullOrEmpty(nowPlayingClaimUrl)) {
+                        urlParam = nowPlayingClaimUrl;
+                    } else {
+                        urlParam = nowPlayingClaim.getCanonicalUrl();
+                    }
+                    openFileUrl(urlParam);
                 }
             }
         });
@@ -2238,8 +2246,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
     public void checkNowPlaying() {
         // Don't show the toolbar when returning from the Share Activity
-        if (getSupportFragmentManager().findFragmentByTag(FILE_VIEW_TAG) == null)
+        if (getSupportFragmentManager().findFragmentByTag(FILE_VIEW_TAG) == null) {
             findViewById(R.id.toolbar).setVisibility(View.VISIBLE);
+        }
         if (nowPlayingClaim != null) {
             findViewById(R.id.miniplayer).setVisibility(View.VISIBLE);
             ((TextView) findViewById(R.id.global_now_playing_title)).setText(nowPlayingClaim.getTitle());


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: Partially #232 

## What is the current behavior?
When clicking on global player, content nothing happens
## What is the new behavior?
When clicked on global player, content is expanded