### PR TITLE
Set playlist title when playing from non-local collections

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -657,6 +657,7 @@ public class FileViewFragment extends BaseFragment implements
             if (fileClaim != null && !invalidRepost) {
                 if (Claim.TYPE_COLLECTION.equalsIgnoreCase(fileClaim.getValueType()) &&
                         fileClaim.getClaimIds() != null && fileClaim.getClaimIds().size() > 0) {
+                    currentPlaylistTitle = fileClaim.getTitleOrName();
                     resolvePlaylistClaimsAndPlayFirst();
                     return;
                 }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #232 (`@richardharriscoaching channel - when you click on a playlist, it shows null (circle) x / x`)

## What is the current behavior?

"null • x/x" being shown when playing from non-local collections

## What is the new behavior?

Playlist title (or name if not available) shown
