### PR TITLE
Claim preview improvements

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -357,6 +357,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         protected final View repostInfoView;
         protected final TextView repostChannelView;
         protected final View selectedOverlayView;
+        protected final TextView viewCountView;
         protected final TextView fileSizeView;
         protected final ProgressBar downloadProgressView;
         protected final TextView deviceView;
@@ -383,6 +384,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
             repostInfoView = v.findViewById(R.id.claim_repost_info);
             repostChannelView = v.findViewById(R.id.claim_repost_channel);
             selectedOverlayView = v.findViewById(R.id.claim_selected_overlay);
+            viewCountView = v.findViewById(R.id.claim_view_count);
             fileSizeView = v.findViewById(R.id.claim_file_size);
             downloadProgressView = v.findViewById(R.id.claim_download_progress);
             deviceView = v.findViewById(R.id.claim_view_device);
@@ -694,6 +696,10 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                     vh.publisherView.setText(signingChannel != null ? signingChannel.getName() : context.getString(R.string.anonymous));
                     vh.publishTimeView.setText(DateUtils.getRelativeTimeSpanString(
                             publishTime, System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
+                    if (vh.viewCountView != null) {
+                        vh.viewCountView.setText(item.getViews() != null ? context.getResources().getQuantityString(
+                                R.plurals.view_count, item.getViews(), item.getViews()) + " •" : null);
+                    }
                     long duration = item.getDuration();
                     vh.durationView.setVisibility((duration > 0 || item.isHighlightLive() || Claim.TYPE_COLLECTION.equalsIgnoreCase(item.getValueType())) ? View.VISIBLE : View.GONE);
                     long lastPlaybackPosition = loadLastPlaybackPosition(item);

--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -350,6 +350,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         protected final TextView vanityUrlView;
         protected final TextView durationView;
         protected final TextView titleView;
+        protected final ImageView publisherThumbnailView;
         protected final TextView publisherView;
         protected final TextView publishTimeView;
         protected final TextView pendingTextView;
@@ -375,6 +376,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
             vanityUrlView = v.findViewById(R.id.claim_vanity_url);
             durationView = v.findViewById(R.id.claim_duration);
             titleView = v.findViewById(R.id.claim_title);
+            publisherThumbnailView = v.findViewById(R.id.claim_publisher_thumbnail);
             publisherView = v.findViewById(R.id.claim_publisher);
             publishTimeView = v.findViewById(R.id.claim_publish_time);
             pendingTextView = v.findViewById(R.id.claim_pending_text);
@@ -669,6 +671,20 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                         vh.thumbnailView.setVisibility(View.VISIBLE);
                     } else {
                         vh.thumbnailView.setVisibility(View.GONE);
+                    }
+
+                    if (vh.publisherThumbnailView != null) {
+                        String publisherThumbnailUrl = item.getSigningChannel().getThumbnailUrl(vh.publisherThumbnailView.getLayoutParams().width, vh.publisherThumbnailView.getLayoutParams().height, 85);
+                        if (!Helper.isNullOrEmpty(publisherThumbnailUrl)) {
+                            Glide.with(context.getApplicationContext())
+                                    .load(publisherThumbnailUrl)
+                                    .centerCrop()
+                                    .placeholder(R.drawable.bg_thumbnail_placeholder)
+                                    .apply(RequestOptions.circleCropTransform())
+                                    .into(vh.publisherThumbnailView);
+                        } else {
+                            vh.publisherThumbnailView.setVisibility(View.GONE);
+                        }
                     }
 
                     BigDecimal cost = item.getActualCost(Lbryio.LBCUSDRate);

--- a/app/src/main/java/com/odysee/app/model/Claim.java
+++ b/app/src/main/java/com/odysee/app/model/Claim.java
@@ -103,6 +103,7 @@ public class Claim {
 
     private boolean highlightLive;
     private int livestreamViewers;
+    private Integer views;
 
     // Collections
     private List<String> claimIds;

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelFragment.java
@@ -717,8 +717,9 @@ public class ChannelFragment extends BaseFragment implements FetchChannelsListen
             FetchStatCountTask task = new FetchStatCountTask(
                     FetchStatCountTask.STAT_SUB_COUNT, claim.getClaimId(), null, new FetchStatCountTask.FetchStatCountHandler() {
                 @Override
-                public void onSuccess(int count) {
+                public void onSuccess(List<Integer> counts) {
                     try {
+                        int count = counts.get(0);
                         String displayText = getResources().getQuantityString(R.plurals.follower_count, count, NumberFormat.getInstance().format(count));
                         Helper.setViewText(textFollowerCount, displayText);
                         Helper.setViewVisibility(textFollowerCount, View.VISIBLE);

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2607,8 +2607,9 @@ public class FileViewFragment extends BaseFragment implements
             FetchStatCountTask task = new FetchStatCountTask(
                     FetchStatCountTask.STAT_VIEW_COUNT, actualClaim.getClaimId(), null, new FetchStatCountTask.FetchStatCountHandler() {
                 @Override
-                public void onSuccess(int count) {
+                public void onSuccess(List<Integer> counts) {
                     try {
+                        int count = counts.get(0);
                         String displayText = getResources().getQuantityString(R.plurals.view_count, count, NumberFormat.getInstance().format(count));
                         View root = getView();
                         if (root != null) {

--- a/app/src/main/java/com/odysee/app/utils/Lbryio.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbryio.java
@@ -347,6 +347,12 @@ public final class Lbryio {
         return params;
     }
 
+    public static Map<String, String> buildSingleListParam(String key, List<String> values) {
+        Map<String, String> params = new HashMap<>();
+        params.put(key, String.join(",", values));
+        return params;
+    }
+
     public static void setLastWalletSync(WalletSync walletSync) {
         synchronized (lock) {
             lastWalletSync = walletSync;

--- a/app/src/main/res/layout-sw360dp/list_item_stream.xml
+++ b/app/src/main/res/layout-sw360dp/list_item_stream.xml
@@ -217,10 +217,17 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content">
                             <TextView
+                                android:id="@+id/claim_view_count"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="4sp"
+                                android:fontFamily="@font/inter" />
+                            <TextView
                                 android:id="@+id/claim_publish_time"
                                 style="@style/Claim_Publish_Time"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
+                                android:layout_toEndOf="@+id/claim_view_count"
                                 android:fontFamily="@font/inter" />
                             <TextView
                                 android:id="@+id/claim_pending_text"

--- a/app/src/main/res/layout-sw360dp/list_item_stream.xml
+++ b/app/src/main/res/layout-sw360dp/list_item_stream.xml
@@ -195,44 +195,51 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
-                    <TextView
-                        android:id="@+id/claim_publisher"
-                        android:background="?attr/selectableItemBackground"
-                        android:clickable="true"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/inter"
-                        style="@style/Claim_Publisher"
-                        android:focusable="true" />
-                    <RelativeLayout
+                    <ImageView
+                        android:id="@+id/claim_publisher_thumbnail"
+                        android:layout_width="40sp"
+                        android:layout_height="40sp"
+                        android:layout_marginEnd="8dp" />
+                    <LinearLayout
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:layout_marginTop="2dp">
+                        android:layout_height="match_parent"
+                        android:orientation="vertical">
                         <TextView
-                            android:id="@+id/claim_publish_time"
+                            android:id="@+id/claim_publisher"
+                            style="@style/Claim_Publisher"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:fontFamily="@font/inter"
-                            style="@style/Claim_Publish_Time" />
-                        <TextView
-                            android:id="@+id/claim_pending_text"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            style="@style/TextView_Light"
-                            android:text="@string/pending"
-                            android:textSize="11sp"
-                            android:textStyle="italic"
-                            android:visibility="gone" />
-
-                        <TextView
-                            android:id="@+id/claim_file_size"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentEnd="true"
-                            style="@style/TextView_Light"
-                            android:textSize="11sp" />
-                    </RelativeLayout>
+                            android:background="?attr/selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:fontFamily="@font/inter" />
+                        <RelativeLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
+                            <TextView
+                                android:id="@+id/claim_publish_time"
+                                style="@style/Claim_Publish_Time"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:fontFamily="@font/inter" />
+                            <TextView
+                                android:id="@+id/claim_pending_text"
+                                style="@style/TextView_Light"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/pending"
+                                android:textSize="11sp"
+                                android:textStyle="italic"
+                                android:visibility="gone" />
+                            <TextView
+                                android:id="@+id/claim_file_size"
+                                style="@style/TextView_Light"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_alignParentEnd="true"
+                                android:textSize="11sp" />
+                        </RelativeLayout>
+                    </LinearLayout>
 
                 </LinearLayout>
                 <!-- download progress bar -->


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #232

- `Add channel profile thumbnail` (under `Claim previews` section)
- `add view counts to all videos (can batch the view api)` (under `Channel pages` section)

## What is the current behavior?

Only Publisher name and publish time shown

## What is the new behavior?

Publisher channel thumbnail shown, publish time moved below publisher name (same as on odysee.com)

(In channel page) view count shown next to publish time (separated by `•`)
