### PR TITLE
Set viewCountView visibility GONE when claim has no view count

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -697,6 +697,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                     vh.publishTimeView.setText(DateUtils.getRelativeTimeSpanString(
                             publishTime, System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
                     if (vh.viewCountView != null) {
+                        vh.viewCountView.setVisibility((item.getViews() != null && item.getViews() != 0) ? View.VISIBLE : View.GONE);
                         vh.viewCountView.setText(item.getViews() != null ? context.getResources().getQuantityString(
                                 R.plurals.view_count, item.getViews(), item.getViews()) + " •" : null);
                     }

--- a/app/src/main/java/com/odysee/app/tasks/lbryinc/FetchStatCountTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/lbryinc/FetchStatCountTask.java
@@ -52,8 +52,12 @@ public class FetchStatCountTask extends AsyncTask<Void, Void, List<Integer>> {
                             stat == STAT_VIEW_COUNT ? "view_count" : "sub_count",
                             Lbryio.buildSingleListParam("claim_id", claimIds),
                             Helper.METHOD_GET, null));
-            for (int i = 0; i < results.length(); i++) {
-                counts.add(results.getInt(i));
+            if (results != null) {
+                for (int i = 0; i < results.length(); i++) {
+                    counts.add(results.getInt(i));
+                }
+            } else {
+                throw new LbryioResponseException("Could not get stat count results");
             }
         } catch (ClassCastException | LbryioRequestException | LbryioResponseException | JSONException ex) {
             error = ex;

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2612,7 +2612,9 @@ public class FileViewFragment extends BaseFragment implements
                 public void onSuccess(List<Integer> counts) {
                     try {
                         int count = counts.get(0);
-                        String displayText = getResources().getQuantityString(R.plurals.view_count, count, NumberFormat.getInstance().format(count));
+                        String displayText = count != 0
+                                ? getResources().getQuantityString(R.plurals.view_count, count, NumberFormat.getInstance().format(count))
+                                : getResources().getString(R.string.no_views_count);
                         View root = getView();
                         if (root != null) {
                             TextView textViewCount = root.findViewById(R.id.file_view_view_count);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,7 @@
     <string name="create_channel_for_chat">Please create a channel before sending chat messages.</string>
     <string name="could_not_send_chat_message">Your chat message could not be sent at this time. Please try again later.</string>
 
+    <string name="no_views_count">No views</string>
     <plurals name="view_count">
         <item quantity="one">%1$s view</item>
         <item quantity="other">%1$s views</item>


### PR DESCRIPTION
i.e. on all places other than channel content.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Left slightly broken in #248

## What is the current behavior?

Due to 4dp `marginEnd`, publish time view is slightly indented.

## What is the new behavior?

Make view GONE so publish time view is not indented.