### PR TITLE
Fix playback restarting when opening claim from global player

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -2746,7 +2746,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 launchIntent.setAction(Intent.ACTION_VIEW);
                 launchIntent.setData(Uri.parse(nowPlayingClaimUrl));
                 launchIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                return PendingIntent.getActivity(MainActivity.this, 0, launchIntent, 0);
+                return PendingIntent.getActivity(MainActivity.this, 0, launchIntent, PendingIntent.FLAG_IMMUTABLE);
             }
             return null;
         }

--- a/app/src/main/java/com/odysee/app/model/ClaimCacheKey.java
+++ b/app/src/main/java/com/odysee/app/model/ClaimCacheKey.java
@@ -43,6 +43,17 @@ public class ClaimCacheKey {
         return key;
     }
 
+    public static ClaimCacheKey fromClaimCanonicalUrl(Claim claim) {
+        ClaimCacheKey key = new ClaimCacheKey();
+        if (claim != null) {
+            LbryUri url = LbryUri.tryParse(claim.getCanonicalUrl());
+            if (url != null) {
+                key.setUrl(url.toString());
+            }
+        }
+        return key;
+    }
+
     public static ClaimCacheKey fromClaim(Claim claim) {
         ClaimCacheKey key = new ClaimCacheKey();
         if (claim != null) {

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -644,6 +644,8 @@ public class FileViewFragment extends BaseFragment implements
                 }
                 if (fileClaim == null) {
                     resolveUrl(currentUrl);
+                } else {
+                    Lbry.addClaimToCache(fileClaim);
                 }
             } else {
                 checkAndResetNowPlayingClaim();

--- a/app/src/main/java/com/odysee/app/utils/Lbry.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbry.java
@@ -625,6 +625,7 @@ public final class Lbry {
         ClaimCacheKey fullKey = ClaimCacheKey.fromClaim(claim);
         ClaimCacheKey shortUrlKey = ClaimCacheKey.fromClaimShortUrl(claim);
         ClaimCacheKey permanentUrlKey = ClaimCacheKey.fromClaimPermanentUrl(claim);
+        ClaimCacheKey canonicalUrlKey = ClaimCacheKey.fromClaimCanonicalUrl(claim);
 
         if (!Helper.isNullOrEmpty(fullKey.getUrl())) {
             claimCache.put(fullKey, claim);
@@ -634,6 +635,9 @@ public final class Lbry {
         }
         if (!Helper.isNullOrEmpty(shortUrlKey.getUrl())) {
             claimCache.put(shortUrlKey, claim);
+        }
+        if (!Helper.isNullOrEmpty(canonicalUrlKey.getUrl())) {
+            claimCache.put(canonicalUrlKey, claim);
         }
     }
 


### PR DESCRIPTION


## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Fix regression from: https://github.com/OdyseeTeam/odysee-android/commit/dce3e8c0300f9633d223a0a828a428b9cddbb58f

## What is the current behavior?

Playback reloads ("Loading content" and spinner shown) when clicking on global player

## What is the new behavior?

Playback does not reload when clicking on global player

## Other information

- Save canonicalUrl in claimCache.
- Cache claim even when not resolving a repost.
- Add FLAG_IMMUTABLE to createCurrentContentIntent to fix crash on
  Android 12 when clicking global player.
