### PR TITLE
Set Livestream claim release time to start time from API

### DIFF
--- a/app/src/main/java/com/odysee/app/model/Claim.java
+++ b/app/src/main/java/com/odysee/app/model/Claim.java
@@ -18,6 +18,8 @@ import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -444,13 +446,22 @@ public class Claim {
      * @param claimId - The claimId to used for the claim
      * @param liveUrl - The url which should be used for connecting to the livestream
      * @param livestreamViewers - The amount of viewers currently watching the stream
+     * @param startTime - The start time of the stream in ISO 8601 UTC format
      * @return A new Claim object
      */
-    public static Claim fromLiveStatus(String claimId, String liveUrl, int livestreamViewers) {
+    public static Claim fromLiveStatus(String claimId, String liveUrl, int livestreamViewers, String startTime) {
         Claim claim = new Claim();
         claim.setClaimId(claimId);
         claim.setLivestreamUrl(liveUrl);
         claim.setLivestreamViewers(livestreamViewers);
+        StreamMetadata value = new StreamMetadata();
+        try {
+            value.setReleaseTime(ZonedDateTime.parse(startTime).toInstant().getEpochSecond());
+        } catch (DateTimeParseException ex) {
+            ex.printStackTrace();
+            return null;
+        }
+        claim.setValue(value);
         return claim;
     }
 

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
@@ -20,6 +20,8 @@ import com.odysee.app.OdyseeApp;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -397,6 +399,7 @@ public class ChannelContentFragment extends Fragment implements DownloadActionLi
                 livestreamingChannels = isLiveFuture.get();
 
                 Map<String, Integer> viewersForClaim = new HashMap<>();
+                Map<String, Long> releaseTimeForClaim = new HashMap<>();
                 if (livestreamingChannels != null && livestreamingChannels.containsKey(channelId)) {
                     String activeClaimId = null;
                     JSONObject jsonData = livestreamingChannels.get(channelId);
@@ -405,6 +408,12 @@ public class ChannelContentFragment extends Fragment implements DownloadActionLi
                         JSONObject jsonActiveClaimID = jsonData.getJSONObject("ActiveClaim");
                         activeClaimId = jsonActiveClaimID.getString("ClaimID");
                         viewersForClaim.put(activeClaimId, jsonData.getInt("ViewerCount"));
+                        try {
+                            releaseTimeForClaim.put(activeClaimId, ZonedDateTime.parse(
+                                    jsonData.getString("Start")).toInstant().getEpochSecond());
+                        } catch (DateTimeParseException ex) {
+                            ex.printStackTrace();
+                        }
                     }
 
                     if (activeClaimId != null && !activeClaimId.equalsIgnoreCase("Confirming")) {
@@ -429,6 +438,10 @@ public class ChannelContentFragment extends Fragment implements DownloadActionLi
                         Integer viewers = viewersForClaim.get(c.getClaimId());
                         if (viewers != null) {
                             c.setLivestreamViewers(viewers);
+                        }
+                        Long releaseTime = releaseTimeForClaim.get(c.getClaimId());
+                        if (releaseTime != null) {
+                            ((Claim.StreamMetadata) c.getValue()).setReleaseTime(releaseTime);
                         }
                     });
                 }

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -783,9 +783,10 @@ public class FollowingFragment extends BaseFragment implements
                         activeClaimId = activeJson.getString("ClaimID");
                         String livestreamUrl = j.getString("VideoURL");
                         int viewersCount = j.getInt("ViewerCount");
+                        String startTime = j.getString("Start");
                         System.out.println(pair.getKey() + " = " + pair.getValue());
                         if (!activeClaimId.equalsIgnoreCase("Confirming")) {
-                            activeClaims.add(Claim.fromLiveStatus(activeClaimId, livestreamUrl, viewersCount));
+                            activeClaims.add(Claim.fromLiveStatus(activeClaimId, livestreamUrl, viewersCount, startTime));
                             activeClaimIds.add(activeClaimId);
                         }
                     }
@@ -808,7 +809,7 @@ public class FollowingFragment extends BaseFragment implements
                 return null;
             } else {
                 mostRecentClaims.stream().forEach(c -> {
-                    Claim p = activeClaims.stream().filter(g -> g.getClaimId().equalsIgnoreCase(c.getClaimId())).findFirst().orElse(null);
+                    Claim p = activeClaims.stream().filter(g -> g != null && g.getClaimId().equalsIgnoreCase(c.getClaimId())).findFirst().orElse(null);
 
                     if (p != null) {
                         Claim ac = activeClaims.get(activeClaims.indexOf(p));
@@ -816,6 +817,8 @@ public class FollowingFragment extends BaseFragment implements
                         c.setLive(true);
                         c.setLivestreamUrl(ac.getLivestreamUrl());
                         c.setLivestreamViewers(ac.getLivestreamViewers());
+                        ((Claim.StreamMetadata) c.getValue()).setReleaseTime(
+                                ((Claim.StreamMetadata) ac.getValue()).getReleaseTime());
                     }
                 });
             }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #232 (`For the livestream content date - use the started at from livestream api (and not claim date)`)

## What is the current behavior?

Claim publish date used.

## What is the new behavior?

Date from `Start` field from Livestream API used.
