### PR TITLE
Only show "LIVE" for total duration on livestreams

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -350,6 +350,8 @@ public class FileViewFragment extends BaseFragment implements
     private String commentHash;
     private String claimLivestreamUrl;
 
+    private boolean isLivestream;
+
     @Override
     public void onCreate(@androidx.annotation.Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -1931,6 +1933,7 @@ public class FileViewFragment extends BaseFragment implements
 
             // livestream, so we load up the messages and initialise the websocket
             initLivestreamChat();
+            isLivestream = true;
         }
         if (claimToRender.isPlayable() && MainActivity.appPlayer != null
                 && ((!claimToRender.isLive() && claimLivestreamUrl == null) || (claimToRender.isLive() && claimToRender.getLivestreamUrl() != null))) {
@@ -3985,7 +3988,9 @@ public class FileViewFragment extends BaseFragment implements
     private void renderTotalDuration() {
         View view = getView();
         if (view != null) {
-            Helper.setViewText(view.findViewById(R.id.player_duration_total), Helper.formatDuration(Double.valueOf(totalDuration / 1000.0).longValue()));
+            Helper.setViewText(view.findViewById(R.id.player_duration_total), isLivestream
+                    ? getResources().getString(R.string.live_duration)
+                    : Helper.formatDuration(Double.valueOf(totalDuration / 1000.0).longValue()));
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <!-- File view -->
     <string name="user_not_live_yet">%1$s isn\'t live right now. Check back later to watch the stream.</string>
     <string name="live">Live</string>
+    <string name="live_duration">LIVE</string>
     <string name="soon">Soon</string>
     <string name="tags">Tags</string>
     <string name="like_desc">Fire icon</string>


### PR DESCRIPTION
Elapsed duration is still shown as it works properly.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #232 (`hide time elapsed / time remaining on livestreams (show otherwise)`)

## What is the current behavior?

Total time is shown and jumps in several second increments (what's buffered?)

## What is the new behavior?

"LIVE" is shown in place of total time
