### PR TITLE
Following: Fix livestreams not being shown when filtering by channel

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -218,7 +218,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                             int positionToInsert = position > 0 ? position - 1 : 0;
                             items.add(positionToInsert, claim);
                             notifyItemInserted(positionToInsert);
-                        } else if (items.size() > 0) {
+                        } else {
                             // There is no item on the list of items which is not a livestream
                             items.add(claim);
                             notifyItemInserted(items.size());


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #232 (`Following page - if you click Filter and then click on a channel, it stops showing active livestreams. If you click All, still doesn't show them. Need to leave and come back.`)

## What is the current behavior?

`addItems` checks that `items` is not empty when in the livestreams code path, so it will never add if the first claim is a livestream.

## What is the new behavior?

Remove `items` empty check in the livestreams code path, this is the same behaviour as in the other code path.
