### PR TITLE
Disable Google Cast dependency while not implemented

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,9 +104,9 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-core:2.16.0'
     implementation 'com.google.android.exoplayer:exoplayer-dash:2.16.0'
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.16.0'
-    fullImplementation 'com.google.android.exoplayer:extension-cast:2.16.0'
     implementation 'com.google.android.exoplayer:extension-mediasession:2.16.0'
     implementation 'com.google.android.exoplayer:exoplayer-hls:2.16.0'
+//    fullImplementation 'com.google.android.exoplayer:extension-cast:2.16.0'
 
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## What is the current behavior?
Gradle fetches Google Cast library, although it is not needed at compile-time
## What is the new behavior?
The dependency has been disabled. This makes the app still compilable
## Other information
The dependency has also been moved a few lines below. Previous lines are about the player or its codecs. The Cast dependency is different than that, although tightly related.
