### PR TITLE
Set playback rate to 1x when livestream has reached live edge

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -78,6 +78,7 @@ import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.TracksInfo;
 import com.google.android.exoplayer2.TracksInfo.TrackGroupInfo;
 import com.google.android.exoplayer2.audio.AudioAttributes;
@@ -463,6 +464,14 @@ public class FileViewFragment extends BaseFragment implements
                     loadingQualityChanged = false;
 
                     showBuffering();
+
+                    Timeline.Window window = MainActivity.appPlayer.getCurrentTimeline()
+                            .getWindow(MainActivity.appPlayer.getCurrentMediaItemIndex(), new Timeline.Window());
+                    long currentPosition = MainActivity.appPlayer.getCurrentPosition();
+                    long defaultPosition = window.getDefaultPositionMs();
+                    if (currentPosition >= defaultPosition) {
+                        setPlaybackSpeed(MainActivity.appPlayer, 100);
+                    }
                 } else if (playbackState == Player.STATE_ENDED) {
                     playNextItemInPlaylist();
                 } else {
@@ -2516,8 +2525,7 @@ public class FileViewFragment extends BaseFragment implements
 
     private void setPlaybackSpeed(Player player, int speedId) {
         float speed = speedId / 100.0f;
-        PlaybackParameters params = new PlaybackParameters(speed);
-        player.setPlaybackParameters(params);
+        player.setPlaybackSpeed(speed);
 
         updatePlaybackSpeedView(getView());
     }


### PR DESCRIPTION
- When buffer event happens, get player timeline window and compare
  playback position with default (close to edge) position. If current
  playback position is newer than default, set playback rate to 1x.
- Use setPlaybackSpeed() instead of setPlaybackParameters().

Note that this _can_ cause playback rate to reset if skipping to an area
that not loaded yet _and_ in front of the live edge. It shouldn't be a
major problem as when just watching at 2x to catch up on a livestream it
wouldn't go past the buffered area.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## Fixes

Issue Number: #232 (`If someone changes playback rate, and then it catches up to the live tip, change rate back to 1x (otherwise you continue to get buffering cause it's trying to play faster). Hide rate playback for now on lives if not possible/difficult.`)

## What is the current behavior?

A lot of buffering as it's attempting to continue playing at a faster rate

## What is the new behavior?

Set playback rate to 1x when live edge is reached
