### PR TITLE
Stop video autoplaying/stopping when switching to another claim

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -360,7 +360,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public static final String PREFERENCE_KEY_INSTALL_ID = "com.odysee.app.InstallId";
     public static final String PREFERENCE_KEY_INTERNAL_BACKGROUND_PLAYBACK = "com.odysee.app.preference.userinterface.BackgroundPlayback";
     public static final String PREFERENCE_KEY_INTERNAL_BACKGROUND_PLAYBACK_PIP_MODE = "com.odysee.app.preference.userinterface.BackgroundPlaybackPIPMode";
-    public static final String PREFERENCE_KEY_INTERNAL_MEDIA_AUTOPLAY = "com.odysee.app.preference.userinterface.MediaAutoplay";
+    public static final String PREFERENCE_KEY_INTERNAL_AUTOPLAY_MEDIA = "com.odysee.app.preference.userinterface.AutoplayMedia";
     public static final String PREFERENCE_KEY_INTERNAL_WIFI_DEFAULT_QUALITY = "com.odysee.app.preference.userinterface.WifiDefaultQuality";
     public static final String PREFERENCE_KEY_INTERNAL_MOBILE_DEFAULT_QUALITY = "com.odysee.app.preference.userinterface.MobileDefaultQuality";
     public static final String PREFERENCE_KEY_INTERNAL_PLAYBACK_DEFAULT_SPEED = "com.odysee.app.preference.userinterface.PlaybackDefaultSpeed";
@@ -396,6 +396,10 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public static final String APP_SETTING_DARK_MODE_NIGHT = "night";
     public static final String APP_SETTING_DARK_MODE_NOTNIGHT = "notnight";
     public static final String APP_SETTING_DARK_MODE_SYSTEM = "system";
+
+    public static final String APP_SETTING_AUTOPLAY_NEVER = "never";
+    public static final String APP_SETTING_AUTOPLAY_NOTHING_PLAYING = "nothing_playing";
+    public static final String APP_SETTING_AUTOPLAY_ALWAYS = "always";
 
     private static final String TAG = "OdyseeMain";
     private static final String FILE_VIEW_TAG = "FileView";
@@ -1200,9 +1204,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         return sp.getBoolean(PREFERENCE_KEY_INTERNAL_BACKGROUND_PLAYBACK_PIP_MODE, false);
     }
 
-    public boolean isMediaAutoplayEnabled() {
+    public String mediaAutoplayEnabled() {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
-        return sp.getBoolean(PREFERENCE_KEY_INTERNAL_MEDIA_AUTOPLAY, true);
+        return sp.getString(PREFERENCE_KEY_INTERNAL_AUTOPLAY_MEDIA, APP_SETTING_AUTOPLAY_NOTHING_PLAYING);
     }
 
     public int wifiDefaultQuality() {

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -429,6 +429,7 @@ public class FileViewFragment extends BaseFragment implements
                     renderTotalDuration();
                     scheduleElapsedPlayback();
                     hideBuffering();
+                    setPlayerSurfaceVisibility(View.VISIBLE);
 
                     if (loadingNewClaim) {
                         setPlaybackSpeedToDefault();
@@ -773,6 +774,7 @@ public class FileViewFragment extends BaseFragment implements
                     MainActivity.stopExoplayer();
                 }
             }
+            setPlayerSurfaceVisibility(View.INVISIBLE);
         }
     }
 
@@ -1021,6 +1023,17 @@ public class FileViewFragment extends BaseFragment implements
             view.setVisibility(View.VISIBLE);
             view.setPlayer(null);
             view.setPlayer(MainActivity.appPlayer);
+        }
+    }
+
+    private void setPlayerSurfaceVisibility(int visibility) {
+        View root = getView();
+        if (root != null) {
+            PlayerView view = root.findViewById(R.id.file_view_exoplayer_view);
+            View surfaceView = view.getVideoSurfaceView();
+            if (surfaceView != null) {
+                surfaceView.setVisibility(visibility);
+            }
         }
     }
 

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2082,10 +2082,23 @@ public class FileViewFragment extends BaseFragment implements
                     // claim already playing
                     showExoplayerView();
                     playMedia();
-                } else if (MainActivity.nowPlayingClaim == null) {
-                    onMainActionButtonClicked();
-                } else if (claimToRender.isViewable()) {
-                    restoreMainActionButton();
+                } else {
+                    String mediaAutoplay = Objects.requireNonNull((MainActivity) (getActivity())).mediaAutoplayEnabled();
+                    if (MainActivity.nowPlayingClaim == null) {
+                        if (!mediaAutoplay.equals(MainActivity.APP_SETTING_AUTOPLAY_NEVER) || claimToRender.isViewable()) {
+                            onMainActionButtonClicked();
+                        } else if (claimToRender.isPlayable()) {
+                            if (root != null) {
+                                root.findViewById(R.id.file_view_main_action_button).setVisibility(View.INVISIBLE);
+                            }
+                        }
+                    } else {
+                        if (mediaAutoplay.equals(MainActivity.APP_SETTING_AUTOPLAY_ALWAYS)) {
+                            onMainActionButtonClicked();
+                        } else if (claimToRender.isViewable()) {
+                            restoreMainActionButton();
+                        }
+                    }
                 }
             } else if (claimToRender.isViewable() && Lbry.SDK_READY) {
                 onMainActionButtonClicked();
@@ -2275,7 +2288,7 @@ public class FileViewFragment extends BaseFragment implements
                     ((MainActivity) context).setNowPlayingClaim(claimToPlay, currentUrl);
                 }
 
-                MainActivity.appPlayer.setPlayWhenReady(Objects.requireNonNull((MainActivity) (getActivity())).isMediaAutoplayEnabled());
+                MainActivity.appPlayer.setPlayWhenReady(true);
 
                 if (claimToPlay.hasSource()) {
                     getStreamingUrlAndInitializePlayer(claimToPlay);

--- a/app/src/main/res/drawable/ic_play_arrow_shadow.xml
+++ b/app/src/main/res/drawable/ic_play_arrow_shadow.xml
@@ -1,0 +1,12 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M8,5 v14 l11,-7 z"
+        android:strokeColor="@color/black"
+        android:strokeAlpha="0.25"
+        android:strokeWidth="2" />
+    <path android:pathData="M8,5 v14 l11,-7 z"
+        android:strokeColor="@color/white"
+        android:strokeAlpha="0.75"
+        android:strokeWidth="1.7" />
+</vector>

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -60,6 +60,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
 
+                <ImageView
+                    android:id="@+id/file_view_play"
+                    android:layout_width="88dp"
+                    android:layout_height="88dp"
+                    android:layout_centerInParent="true"
+                    android:src="@drawable/ic_play_arrow_shadow"
+                    android:visibility="invisible" />
+
                 <ProgressBar
                     android:id="@+id/file_view_main_action_loading"
                     android:layout_width="36dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -353,6 +353,16 @@
     <string name="participate_in_data_network">Participate in the data network (requires app and background service restart)</string>
     <string name="send_buffering_events">Send buffering events to LBRY servers</string>
 
+    <string-array name="media_autoplay">
+        <item>Never</item>
+        <item>Only when nothing is playing</item>
+        <item>Always</item>
+    </string-array>
+    <string-array name="media_autoplay_values">
+        <item>never</item>
+        <item>nothing_playing</item>
+        <item>always</item>
+    </string-array>
     <string-array name="available_qualities">
         <item>@string/auto_quality</item>
         <item>1080p</item>

--- a/app/src/main/res/xml-v29/settings.xml
+++ b/app/src/main/res/xml-v29/settings.xml
@@ -18,12 +18,15 @@
             app:title="@string/enable_background_playback_pip_mode"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
-        <SwitchPreferenceCompat
-            app:key="com.odysee.app.preference.userinterface.MediaAutoplay"
-            app:defaultValue="true"
+        <DropDownPreference
+            app:key="com.odysee.app.preference.userinterface.AutoplayMedia"
+            app:entries="@array/media_autoplay"
+            app:entryValues="@array/media_autoplay_values"
+            app:defaultValue="nothing_playing"
             app:title="@string/enable_autoplay"
             app:singleLineTitle="false"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:summary="%s" />
         <DropDownPreference
             app:key="com.odysee.app.preference.userinterface.WifiDefaultQuality"
             app:entries="@array/available_qualities"

--- a/app/src/main/res/xml-v29/settings.xml
+++ b/app/src/main/res/xml-v29/settings.xml
@@ -24,9 +24,9 @@
             app:entryValues="@array/media_autoplay_values"
             app:defaultValue="nothing_playing"
             app:title="@string/enable_autoplay"
+            app:summary="%s"
             app:singleLineTitle="false"
-            app:iconSpaceReserved="false"
-            app:summary="%s" />
+            app:iconSpaceReserved="false" />
         <DropDownPreference
             app:key="com.odysee.app.preference.userinterface.WifiDefaultQuality"
             app:entries="@array/available_qualities"

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -18,12 +18,15 @@
             app:title="@string/enable_background_playback_pip_mode"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
-        <SwitchPreferenceCompat
-            app:key="com.odysee.app.preference.userinterface.MediaAutoplay"
-            app:defaultValue="true"
+        <DropDownPreference
+            app:key="com.odysee.app.preference.userinterface.AutoplayMedia"
+            app:entries="@array/media_autoplay"
+            app:entryValues="@array/media_autoplay_values"
+            app:defaultValue="nothing_playing"
             app:title="@string/enable_autoplay"
             app:singleLineTitle="false"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:summary="%s" />
         <DropDownPreference
             app:key="com.odysee.app.preference.userinterface.WifiDefaultQuality"
             app:entries="@array/available_qualities"

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -24,9 +24,9 @@
             app:entryValues="@array/media_autoplay_values"
             app:defaultValue="nothing_playing"
             app:title="@string/enable_autoplay"
+            app:summary="%s"
             app:singleLineTitle="false"
-            app:iconSpaceReserved="false"
-            app:summary="%s" />
+            app:iconSpaceReserved="false" />
         <DropDownPreference
             app:key="com.odysee.app.preference.userinterface.WifiDefaultQuality"
             app:entries="@array/available_qualities"


### PR DESCRIPTION
Add play icon (used instead of main action button) for manually starting
videos.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #232 (`When in miniplayer mode and navigating to another claim, it auto starts - should continue playing, and allow user to click play manually.`)

## What is the current behavior?

Playback autostarts when switching to another claim.

## What is the new behavior?

Old video keeps playing, new claim is rendered with a play icon and tapping the the media area starts playback.
