### PR TITLE
Hardcode videoIsTranscoded = true on livestreams

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2327,6 +2327,7 @@ public class FileViewFragment extends BaseFragment implements
 
                     if (mediaSourceUrl != null) {
                         if (!mediaSourceUrl.equals("notlive")) {
+                            MainActivity.videoIsTranscoded = true;
                             Map<String, String> defaultRequestProperties = new HashMap<>(1);
                             defaultRequestProperties.put("Referer", "https://bitwave.tv");
                             dataSourceFactory.setDefaultRequestProperties(defaultRequestProperties);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Fix quality selector not being shown on livestreams.

Issue Number: #232 (`missing quality options under Auto (confirmed stream had em)`)

## What is the current behavior?

No quality options on livestreams as it is not considered a transcoded stream

## What is the new behavior?

Hardcode that livestreams are transcoded so those that _are_ have quality selection, and those that don't just have a single quality.
