### PR TITLE
Don't include list related context menu items on playlists

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -399,9 +399,18 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
 
         @Override
         public void onCreateContextMenu(ContextMenu contextMenu, View view, ContextMenu.ContextMenuInfo contextMenuInfo) {
-            contextMenu.add(contextGroupId, R.id.action_add_to_watch_later, Menu.NONE, R.string.watch_later);
-            contextMenu.add(contextGroupId, R.id.action_add_to_favorites, Menu.NONE, R.string.favorites);
-            contextMenu.add(contextGroupId, R.id.action_add_to_lists, Menu.NONE, R.string.add_to_lists);
+            RecyclerView.Adapter<? extends RecyclerView.ViewHolder> adapter = getBindingAdapter();
+            if (adapter instanceof ClaimListAdapter) {
+                ClaimListAdapter claimListAdapter = ((ClaimListAdapter) adapter);
+                final Claim original = claimListAdapter.getItems().get(getAbsoluteAdapterPosition());
+                final Claim item = Claim.TYPE_REPOST.equalsIgnoreCase(original.getValueType()) ?
+                        (original.getRepostedClaim() != null ? original.getRepostedClaim() : original): original;
+                if (!Claim.TYPE_COLLECTION.equalsIgnoreCase(item.getValueType())) {
+                    contextMenu.add(contextGroupId, R.id.action_add_to_watch_later, Menu.NONE, R.string.watch_later);
+                    contextMenu.add(contextGroupId, R.id.action_add_to_favorites, Menu.NONE, R.string.favorites);
+                    contextMenu.add(contextGroupId, R.id.action_add_to_lists, Menu.NONE, R.string.add_to_lists);
+                }
+            }
             contextMenu.add(contextGroupId, R.id.action_block, Menu.NONE, R.string.block_channel);
         }
     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #232 (`Can click "Watch later" and other options on playlists - don't make sense?`)

## What is the current behavior?

"Watch later", "Favorites", "Add to Lists" options are shown in context menu but don't work for playlists.

## What is the new behavior?

Only "Block channel" shown in context menu for playlists.