### PR TITLE
Hide play/pause when buffering

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -4010,6 +4010,7 @@ public class FileViewFragment extends BaseFragment implements
             root.findViewById(R.id.player_buffering_progress).setVisibility(View.VISIBLE);
 
             PlayerView playerView = root.findViewById(R.id.file_view_exoplayer_view);
+            playerView.findViewById(R.id.player_play_pause).setVisibility(View.INVISIBLE);
             playerView.findViewById(R.id.player_skip_back_10).setVisibility(View.INVISIBLE);
             playerView.findViewById(R.id.player_skip_forward_10).setVisibility(View.INVISIBLE);
         }
@@ -4021,6 +4022,7 @@ public class FileViewFragment extends BaseFragment implements
             root.findViewById(R.id.player_buffering_progress).setVisibility(View.INVISIBLE);
 
             PlayerView playerView = root.findViewById(R.id.file_view_exoplayer_view);
+            playerView.findViewById(R.id.player_play_pause).setVisibility(View.VISIBLE);
             playerView.findViewById(R.id.player_skip_back_10).setVisibility(View.VISIBLE);
             playerView.findViewById(R.id.player_skip_forward_10).setVisibility(View.VISIBLE);
         }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #232 (`see spinner over pause button during initial video loads (hide pause, make spinner bigger/nicer?)`)

## What is the current behavior?

Loading spinner is shown and it's smaller than play/pause button.

## What is the new behavior?

Play/pause button hidden while buffering.
