### PR TITLE
Fix editing-time error about String.join()

### DIFF
--- a/app/src/main/java/com/odysee/app/utils/Lbryio.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbryio.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.odysee.app.MainActivity;
 import com.odysee.app.exceptions.AuthTokenInvalidatedException;
@@ -349,7 +350,12 @@ public final class Lbryio {
 
     public static Map<String, String> buildSingleListParam(String key, List<String> values) {
         Map<String, String> params = new HashMap<>();
-        params.put(key, String.join(",", values));
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
+            params.put(key, String.join(",", values));
+        } else {
+            String joined = values.stream().collect(Collectors.joining(","));
+            params.put(key, joined);
+        }
         return params;
     }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## What is the current behavior?
When editing Lbryio.java file, an error is shown on String.join() method usage on API Level 25-
## What is the new behavior?
The error is no longer shown.
## Other information
According to Android official site, String.join is no part of the desugaring, So this would make the app crash when trying to execute that method. However,after testing on Android 7 -API Level 24-, the app is not crashing and method is returning the expected comma-separated value.

Anyway, this PR is about removing that editing-time error. App is compiling without issues and running as expected both on current source code and with this PR applied.
