### PR TITLE
Don't URL encode query on Lighthouse

### DIFF
--- a/app/src/main/java/com/odysee/app/utils/Lighthouse.java
+++ b/app/src/main/java/com/odysee/app/utils/Lighthouse.java
@@ -6,9 +6,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,59 +39,54 @@ public class Lighthouse {
     }
 
     public static List<Claim> search(String rawQuery, int size, int from, boolean nsfw, String relatedTo) throws LbryRequestException, LbryResponseException {
-        try {
-            Uri.Builder uriBuilder = Uri.parse(String.format("%s/search", CONNECTION_STRING)).buildUpon().
-                    appendQueryParameter("s", URLEncoder.encode(rawQuery, StandardCharsets.UTF_8.name())).
-                    appendQueryParameter("resolve", "true").
-                    appendQueryParameter("size", String.valueOf(size)).
-                    appendQueryParameter("from", String.valueOf(from));
-            if (!nsfw) {
-                uriBuilder.appendQueryParameter("nsfw", String.valueOf(nsfw).toLowerCase());
-            }
-            if (!Helper.isNullOrEmpty(relatedTo)) {
-                uriBuilder.appendQueryParameter("related_to", relatedTo);
-            }
-
-            Map<String, Object> cacheKey = buildSearchOptionsKey(rawQuery, size, from, nsfw, relatedTo);
-            if (searchCache.containsKey(cacheKey)) {
-                return searchCache.get(cacheKey);
-            }
-
-            List<Claim> results = new ArrayList<>();
-            Request request = new Request.Builder().url(uriBuilder.toString()).build();
-            OkHttpClient client = new OkHttpClient.Builder().readTimeout(30, TimeUnit.SECONDS).build();
-            ResponseBody responseBody = null;
-            Response response = null;
-            try {
-                response = client.newCall(request).execute();
-                if (response.code() == 200) {
-                    responseBody = response.body();
-                    if (responseBody != null) {
-                        JSONArray array = new JSONArray(responseBody.string());
-                        for (int i = 0; i < array.length(); i++) {
-                            Claim claim = Claim.fromSearchJSONObject(array.getJSONObject(i));
-                            results.add(claim);
-                        }
-                    }
-                    searchCache.put(cacheKey, results);
-                } else {
-                    throw new LbryResponseException(response.message());
-                }
-            } catch (IOException ex) {
-                throw new LbryRequestException(String.format("search request for '%s' failed", rawQuery), ex);
-            } catch (JSONException ex) {
-                throw new LbryResponseException(String.format("the search response for '%s' could not be parsed", rawQuery), ex);
-            } finally {
-                if (responseBody != null) {
-                    response.close();
-                }
-            }
-
-            return results;
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-            return null;
+        Uri.Builder uriBuilder = Uri.parse(String.format("%s/search", CONNECTION_STRING)).buildUpon().
+                appendQueryParameter("s", rawQuery).
+                appendQueryParameter("resolve", "true").
+                appendQueryParameter("size", String.valueOf(size)).
+                appendQueryParameter("from", String.valueOf(from));
+        if (!nsfw) {
+            uriBuilder.appendQueryParameter("nsfw", String.valueOf(nsfw).toLowerCase());
         }
+        if (!Helper.isNullOrEmpty(relatedTo)) {
+            uriBuilder.appendQueryParameter("related_to", relatedTo);
+        }
+
+        Map<String, Object> cacheKey = buildSearchOptionsKey(rawQuery, size, from, nsfw, relatedTo);
+        if (searchCache.containsKey(cacheKey)) {
+            return searchCache.get(cacheKey);
+        }
+
+        List<Claim> results = new ArrayList<>();
+        Request request = new Request.Builder().url(uriBuilder.toString()).build();
+        OkHttpClient client = new OkHttpClient.Builder().readTimeout(30, TimeUnit.SECONDS).build();
+        ResponseBody responseBody = null;
+        Response response = null;
+        try {
+            response = client.newCall(request).execute();
+            if (response.code() == 200) {
+                responseBody = response.body();
+                if (responseBody != null) {
+                    JSONArray array = new JSONArray(responseBody.string());
+                    for (int i = 0; i < array.length(); i++) {
+                        Claim claim = Claim.fromSearchJSONObject(array.getJSONObject(i));
+                        results.add(claim);
+                    }
+                }
+                searchCache.put(cacheKey, results);
+            } else {
+                throw new LbryResponseException(response.message());
+            }
+        } catch (IOException ex) {
+            throw new LbryRequestException(String.format("search request for '%s' failed", rawQuery), ex);
+        } catch (JSONException ex) {
+            throw new LbryResponseException(String.format("the search response for '%s' could not be parsed", rawQuery), ex);
+        } finally {
+            if (responseBody != null) {
+                response.close();
+            }
+        }
+
+        return results;
     }
 
     public static List<UrlSuggestion> autocomplete(String text) throws LbryRequestException, LbryResponseException {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
This could lead to query string to be encoded twice
## What is the new behavior?
Double encoding is no longer possible
## Other information
@ktprograms are you happy with this change?
