### PR TITLE
Show publish time as relative always, except on FileViewFragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,6 +138,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
 
+    implementation 'org.ocpsoft.prettytime:prettytime:5.0.2.Final'
+
     testImplementation 'junit:junit:4.12'
 //    androidTestImplementation 'androidx.test:runner:1.3.0'
 //    androidTestImplementation 'androidx.test:rules:1.3.0'

--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.icu.text.CompactDecimalFormat;
 import android.os.Build;
-import android.text.format.DateUtils;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -43,6 +42,7 @@ import com.odysee.app.exceptions.LbryUriException;
 import com.odysee.app.listener.SelectionModeListener;
 import com.odysee.app.model.Claim;
 import com.odysee.app.model.LbryFile;
+import com.odysee.app.utils.FormatTime;
 import com.odysee.app.utils.Helper;
 import com.odysee.app.utils.LbryUri;
 import com.odysee.app.utils.Lbryio;
@@ -703,8 +703,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                     vh.feeView.setText(cost.doubleValue() > 0 ? Helper.shortCurrencyFormat(cost.doubleValue()) : "Paid");
                     vh.alphaView.setText(item.getName().substring(0, Math.min(5, item.getName().length() - 1)));
                     vh.publisherView.setText(signingChannel != null ? signingChannel.getTitleOrName() : context.getString(R.string.anonymous));
-                    vh.publishTimeView.setText(DateUtils.getRelativeTimeSpanString(
-                            publishTime, System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
+                    vh.publishTimeView.setText(FormatTime.fromEpochMillis(publishTime));
                     if (vh.viewCountView != null) {
                         vh.viewCountView.setVisibility((item.getViews() != null && item.getViews() != 0) ? View.VISIBLE : View.GONE);
                         vh.viewCountView.setText(item.getViews() != null ? context.getResources().getQuantityString(
@@ -809,8 +808,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                     }
                     vh.alphaView.setText(item.getName().substring(1, 2).toUpperCase());
                     vh.publisherView.setText(item.getName());
-                    vh.publishTimeView.setText(DateUtils.getRelativeTimeSpanString(
-                            publishTime, System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
+                    vh.publishTimeView.setText(FormatTime.fromEpochMillis(publishTime));
 
                     lp.height = ViewGroup.LayoutParams.WRAP_CONTENT;
                     lp.width = ViewGroup.LayoutParams.MATCH_PARENT;

--- a/app/src/main/java/com/odysee/app/adapter/CommentListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/CommentListAdapter.java
@@ -5,7 +5,6 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.text.format.DateUtils;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -33,6 +32,7 @@ import com.odysee.app.model.Claim;
 import com.odysee.app.model.ClaimCacheKey;
 import com.odysee.app.model.Comment;
 import com.odysee.app.model.Reactions;
+import com.odysee.app.utils.FormatTime;
 import com.odysee.app.utils.Helper;
 import com.odysee.app.utils.Lbry;
 import com.odysee.app.utils.LbryUri;
@@ -375,8 +375,7 @@ public class CommentListAdapter extends RecyclerView.Adapter<CommentListAdapter.
         }
 
         holder.channelName.setText(comment.getChannelName());
-        holder.commentTimeView.setText(DateUtils.getRelativeTimeSpanString(
-                (comment.getTimestamp() * 1000), System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
+        holder.commentTimeView.setText(FormatTime.fromEpochMillis(comment.getTimestamp() * 1000));
         holder.commentText.setText(comment.getText());
 
         Reactions commentReactions = comment.getReactions();

--- a/app/src/main/java/com/odysee/app/adapter/NotificationListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/NotificationListAdapter.java
@@ -3,7 +3,6 @@ package com.odysee.app.adapter;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
-import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -29,6 +28,7 @@ import com.odysee.app.listener.SelectionModeListener;
 import com.odysee.app.model.Claim;
 import com.odysee.app.model.lbryinc.LbryNotification;
 import com.odysee.app.ui.controls.SolidIconView;
+import com.odysee.app.utils.FormatTime;
 import com.odysee.app.utils.Helper;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -202,8 +202,7 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
         vh.titleView.setVisibility(!Helper.isNullOrEmpty(notification.getTitle()) ? View.VISIBLE : View.GONE);
         vh.titleView.setText(notification.getTitle());
         vh.bodyView.setText(notification.getDescription());
-        vh.timeView.setText(DateUtils.getRelativeTimeSpanString(
-                getLocalNotificationTime(notification), System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
+        vh.timeView.setText(FormatTime.fromEpochMillis(notification.getTimestamp().getTime()));
 
         vh.authorThumbnailView.setVisibility(notification.getCommentAuthor() == null || notification.getAuthorThumbnailUrl() == null ? View.INVISIBLE : View.VISIBLE);
         if (notification.getAuthorThumbnailUrl() != null)
@@ -300,17 +299,6 @@ public class NotificationListAdapter extends RecyclerView.Adapter<NotificationLi
         }
 
         notifyDataSetChanged();
-    }
-
-    private long getLocalNotificationTime(LbryNotification notification) {
-        TimeZone utcTZ = TimeZone.getTimeZone("UTC");
-        TimeZone targetTZ = TimeZone.getDefault();
-        Calendar cal = new GregorianCalendar(utcTZ);
-        cal.setTimeInMillis(notification.getTimestamp().getTime());
-
-        cal.add(Calendar.MILLISECOND, utcTZ.getRawOffset() * -1);
-        cal.add(Calendar.MILLISECOND, targetTZ.getRawOffset());
-        return cal.getTimeInMillis();
     }
 
     public interface NotificationClickListener {

--- a/app/src/main/java/com/odysee/app/supplier/NotificationListSupplier.java
+++ b/app/src/main/java/com/odysee/app/supplier/NotificationListSupplier.java
@@ -10,12 +10,11 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -78,9 +77,9 @@ public class NotificationListSupplier implements Supplier<List<LbryNotification>
                         notification.setSeen(Helper.getJSONBoolean("is_seen", false, item));
 
                         try {
-                            SimpleDateFormat dateFormat = new SimpleDateFormat(Helper.ISO_DATE_FORMAT_JSON, Locale.US);
-                            notification.setTimestamp(dateFormat.parse(Helper.getJSONString("created_at", dateFormat.format(new Date()), item)));
-                        } catch (ParseException ex) {
+                            String created = Helper.getJSONString("created_at", null, item);
+                            notification.setTimestamp(created == null ? new Date() : Date.from(Instant.parse(created)));
+                        } catch (DateTimeParseException ex) {
                             notification.setTimestamp(new Date());
                         }
 

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -24,7 +24,6 @@ import android.os.Looper;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.text.format.DateUtils;
 import android.text.method.LinkMovementMethod;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -129,6 +128,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -2066,8 +2069,8 @@ public class FileViewFragment extends BaseFragment implements
             if (metadata instanceof Claim.StreamMetadata) {
                 Claim.StreamMetadata streamMetadata = (Claim.StreamMetadata) metadata;
                 long publishTime = streamMetadata.getReleaseTime() > 0 ? streamMetadata.getReleaseTime() * 1000 : claimToRender.getTimestamp() * 1000;
-                ((TextView) root.findViewById(R.id.file_view_publish_time)).setText(DateUtils.getRelativeTimeSpanString(
-                        publishTime, System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
+                ((TextView) root.findViewById(R.id.file_view_publish_time)).setText(DateTimeFormatter.ofLocalizedDate(
+                        FormatStyle.MEDIUM).format(Instant.ofEpochMilli(publishTime).atZone(ZoneId.systemDefault())));
 
                 Fee fee = streamMetadata.getFee();
                 if (fee != null && Helper.parseDouble(fee.getAmount(), 0) > 0) {

--- a/app/src/main/java/com/odysee/app/utils/FormatTime.java
+++ b/app/src/main/java/com/odysee/app/utils/FormatTime.java
@@ -1,0 +1,26 @@
+package com.odysee.app.utils;
+
+import org.ocpsoft.prettytime.PrettyTime;
+import org.ocpsoft.prettytime.units.Decade;
+
+import java.util.Date;
+
+/**
+ * Modified from NewPipe <a href="https://github.com/TeamNewPipe/NewPipe/blob/dev/app/src/main/java/org/schabi/newpipe/util/Localization.java">Localization.java</a>
+ */
+public class FormatTime {
+    public static PrettyTime prettyTime;
+
+    private static void initPrettyTime() {
+        prettyTime = new PrettyTime();
+        // Do not use decades as Odysee doesn't either.
+        prettyTime.removeUnit(Decade.class);
+    }
+
+    public static String fromEpochMillis(final long epochMillis) {
+        if (prettyTime == null) {
+            initPrettyTime();
+        }
+        return prettyTime.format(new Date(epochMillis));
+    }
+}


### PR DESCRIPTION
- Add PrettyTime library (also used by NewPipe).
- Create FormatTime helper class.
- Use DateTimeFormatter to show absolute localized time in
  FileViewFragment. There should be at least one place where the
  absolute publish time is visible.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## Fixes

Issue Number: #232 (`check featured dates - some repost dates nothing coming through? see May 21, August 30, 2020, and "days ago" on various claims`)

## What is the current behavior?

Publish times further back than a month or two are shown as absolute date (e.g. `07 May 2020`)

## What is the new behavior?

Relative time shown no matter how far back publish time is.
Absolute time shown in FileViewFragment.
