### PR TITLE
Fix crash getting thumbnail URL for null signing channel

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -676,14 +676,18 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                     }
 
                     if (vh.publisherThumbnailView != null) {
-                        String publisherThumbnailUrl = item.getSigningChannel().getThumbnailUrl(vh.publisherThumbnailView.getLayoutParams().width, vh.publisherThumbnailView.getLayoutParams().height, 85);
-                        if (!Helper.isNullOrEmpty(publisherThumbnailUrl)) {
-                            Glide.with(context.getApplicationContext())
-                                    .load(publisherThumbnailUrl)
-                                    .centerCrop()
-                                    .placeholder(R.drawable.bg_thumbnail_placeholder)
-                                    .apply(RequestOptions.circleCropTransform())
-                                    .into(vh.publisherThumbnailView);
+                        if (item.getSigningChannel() != null) {
+                            String publisherThumbnailUrl = item.getSigningChannel().getThumbnailUrl(vh.publisherThumbnailView.getLayoutParams().width, vh.publisherThumbnailView.getLayoutParams().height, 85);
+                            if (!Helper.isNullOrEmpty(publisherThumbnailUrl)) {
+                                Glide.with(context.getApplicationContext())
+                                        .load(publisherThumbnailUrl)
+                                        .centerCrop()
+                                        .placeholder(R.drawable.bg_thumbnail_placeholder)
+                                        .apply(RequestOptions.circleCropTransform())
+                                        .into(vh.publisherThumbnailView);
+                            } else {
+                                vh.publisherThumbnailView.setVisibility(View.GONE);
+                            }
                         } else {
                             vh.publisherThumbnailView.setVisibility(View.GONE);
                         }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Bug in https://github.com/OdyseeTeam/odysee-android/commit/a67694a5380fe710966aa9d82daab4b12e43f354

## What is the current behavior?

App crashes if claim's signing channel is null while trying to display publisher thumbnail.

## What is the new behavior?

Check if signing channel is null before getting thumbnail URL.
