### PR TITLE
Open Community Guidelines and Help & Support links in-app

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -953,14 +953,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     public void onClick(View view) {
                         popupWindow.dismiss();
                         hideNotifications();
-
-                        CustomTabColorSchemeParams.Builder ctcspb = new CustomTabColorSchemeParams.Builder();
-                        ctcspb.setToolbarColor(ContextCompat.getColor(MainActivity.this, R.color.colorPrimary));
-                        CustomTabColorSchemeParams ctcsp = ctcspb.build();
-
-                        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder().setDefaultColorSchemeParams(ctcsp);
-                        CustomTabsIntent intent = builder.build();
-                        intent.launchUrl(MainActivity.this, Uri.parse("https://odysee.com/@OdyseeHelp:b/Community-Guidelines:c"));
+                        openFileUrl(getResources().getString(R.string.community_guidelines_url));
                     }
                 });
 
@@ -969,14 +962,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     public void onClick(View view) {
                         popupWindow.dismiss();
                         hideNotifications();
-
-                        CustomTabColorSchemeParams.Builder ctcspb = new CustomTabColorSchemeParams.Builder();
-                        ctcspb.setToolbarColor(ContextCompat.getColor(MainActivity.this, R.color.colorPrimary));
-                        CustomTabColorSchemeParams ctcsp = ctcspb.build();
-
-                        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder().setDefaultColorSchemeParams(ctcsp);
-                        CustomTabsIntent intent = builder.build();
-                        intent.launchUrl(MainActivity.this, Uri.parse("https://odysee.com/@OdyseeHelp:b?view=about"));
+                        openChannelUrl(getResources().getString(R.string.help_and_support_url));
                     }
                 });
 
@@ -1435,6 +1421,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         if (!Helper.isNullOrEmpty(source)) {
             params.put("source", source);
         }
+        openFragment(ChannelFragment.class, true, params);
     }
     public void openChannelUrl(String url) {
         openChannelUrl(url, null);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="sign_up_log_in">Sign Up or Log In</string>
     <string name="community_guidelines">Community Guidelines</string>
     <string name="help_and_support">Help &amp; Support</string>
+    <string name="community_guidelines_url" translatable="false">lbry://@OdyseeHelp:b/Community-Guidelines:c</string>
+    <string name="help_and_support_url" translatable="false">lbry://@OdyseeHelp:b</string>
     <string name="no_current_email">No current email. Please try to sign in again.</string>
     <string name="startup_failed">App startup failed. Please check your data connection and try again. If this problem persists, please email hello@lbry.com</string>
     <string name="no_claim_search_content">No content to display at this time. Please refine your selection or check back later.</string>


### PR DESCRIPTION
- Add call to openFragment to openChannelUrl method.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## Fixes

Issue Number: N/A

## What is the current behavior?

Community Guidelines and Help & Support links are opened in a browser within the app

## What is the new behavior?

Community Guidelines and Help & Support links are opened in FileViewFragment/ChannelFragment

## Other information

Note: this no longer goes to the "About" tab when opening Help & Support, if this is desired, I can add it. I am not adding it currently as it would require making the `currentTab` property in ChannelFragment `public`.
