### PR TITLE
Fix tapping on media controls notification not opening player

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -2745,10 +2745,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         @Nullable
         @Override
         public PendingIntent createCurrentContentIntent(Player player) {
-            if (nowPlayingClaimUrl != null) {
+            if (nowPlayingClaimUrl != null || (nowPlayingClaim != null && !Helper.isNullOrEmpty(nowPlayingClaim.getCanonicalUrl()))) {
                 Intent launchIntent = new Intent(MainActivity.this, MainActivity.class);
                 launchIntent.setAction(Intent.ACTION_VIEW);
-                launchIntent.setData(Uri.parse(nowPlayingClaimUrl));
+                if (!Helper.isNullOrEmpty(nowPlayingClaimUrl)) {
+                    launchIntent.setData(Uri.parse(nowPlayingClaimUrl));
+                } else {
+                    launchIntent.setData(Uri.parse(nowPlayingClaim.getCanonicalUrl()));
+                }
                 launchIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
                 return PendingIntent.getActivity(MainActivity.this, 0, launchIntent, PendingIntent.FLAG_IMMUTABLE);
             }


### PR DESCRIPTION
Use nowPlayingClaim.getCanonicalUrl() if nowPlayingClaimUrl is null.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Tapping on media controls notification does nothing

## What is the new behavior?

Tapping on media controls notification opens player
