### PR TITLE
Fix playback speed resetting when jumping around

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -465,12 +465,14 @@ public class FileViewFragment extends BaseFragment implements
 
                     showBuffering();
 
-                    Timeline.Window window = MainActivity.appPlayer.getCurrentTimeline()
-                            .getWindow(MainActivity.appPlayer.getCurrentMediaItemIndex(), new Timeline.Window());
-                    long currentPosition = MainActivity.appPlayer.getCurrentPosition();
-                    long defaultPosition = window.getDefaultPositionMs();
-                    if (currentPosition >= defaultPosition) {
-                        setPlaybackSpeed(MainActivity.appPlayer, 100);
+                    if (isLivestream) {
+                        Timeline.Window window = MainActivity.appPlayer.getCurrentTimeline()
+                                .getWindow(MainActivity.appPlayer.getCurrentMediaItemIndex(), new Timeline.Window());
+                        long currentPosition = MainActivity.appPlayer.getCurrentPosition();
+                        long defaultPosition = window.getDefaultPositionMs();
+                        if (currentPosition >= defaultPosition) {
+                            setPlaybackSpeed(MainActivity.appPlayer, 100);
+                        }
                     }
                 } else if (playbackState == Player.STATE_ENDED) {
                     playNextItemInPlaylist();


### PR DESCRIPTION
Only use timeline window edge logic when playing a livestream.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

When playing at faster speed, then jumping back 10 seconds, playback speed resets to 1x.

## What is the new behavior?

Playback speed doesn't change
