### PR TITLE
Fix default speed and quality ignored on claims from openFileClaim()

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -654,6 +654,7 @@ public class FileViewFragment extends BaseFragment implements
                     resolveUrl(currentUrl);
                 } else {
                     Lbry.addClaimToCache(fileClaim);
+                    loadingNewClaim = true;
                 }
             } else {
                 checkAndResetNowPlayingClaim();


### PR DESCRIPTION
openFileClaim() sets "claim" param, so the `newClaim == null` code path,
which calls onNewClaim(), which sets `loadingNewClaim`, is not called.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

When opening claims from Home tab, default speed and quality settings aren't used.

## What is the new behavior?

Default speed and quality settings used.
