### PR TITLE
Use start/stop events from chat websocket

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -129,6 +129,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -312,8 +315,10 @@ public class FileViewFragment extends BaseFragment implements
     private ImageView dislikeReactionIcon;
     ScheduledFuture<?> futureReactions;
     Reactions reactions;
-    ScheduledFuture<?> futureViewersCount;
     ScheduledFuture<?> futureElapsedPlayback;
+    ScheduledFuture<?> scheduledStartPlaying;
+    ScheduledFuture<?> scheduledStopPlaying;
+    private long livestreamStartingMillis = 0;
 
     private boolean postingComment;
     private boolean fetchingChannels;
@@ -349,6 +354,7 @@ public class FileViewFragment extends BaseFragment implements
     private String claimLivestreamUrl;
 
     private boolean isLivestream;
+    private Map<String, JSONObject> jsonData;
 
     @Override
     public void onCreate(@androidx.annotation.Nullable Bundle savedInstanceState) {
@@ -697,6 +703,36 @@ public class FileViewFragment extends BaseFragment implements
         }
     }
 
+    private void renderPublisherNotBroadcasting(Claim claimToRender) {
+        View root = getView();
+        Context context = getContext();
+        if (root != null && context != null) {
+            root.findViewById(R.id.file_view_livestream_not_live).setVisibility(View.VISIBLE);
+            root.findViewById(R.id.file_view_exoplayer_container).setVisibility(View.GONE);
+            TextView userNotStreaming = root.findViewById(R.id.user_not_streaming);
+            userNotStreaming.setText(context.getString(R.string.user_not_live_yet, claimToRender.getPublisherName()));
+            userNotStreaming.setVisibility(View.VISIBLE);
+            ImageView thumbnailView = root.findViewById(R.id.file_view_livestream_thumbnail);
+            Glide.with(context.getApplicationContext()).
+                    asBitmap().
+                    load(claimToRender.getThumbnailUrl()).
+                    into(thumbnailView);
+        }
+        updatePublishTime(null, claimToRender);
+    }
+
+    private void renderPublisherBroadcasting() {
+        View root = getView();
+        Context context = getContext();
+        if (root != null && context != null) {
+            root.findViewById(R.id.file_view_livestream_not_live).setVisibility(View.GONE);
+            root.findViewById(R.id.file_view_exoplayer_container).setVisibility(View.VISIBLE);
+            TextView userNotStreaming = root.findViewById(R.id.user_not_streaming);
+            userNotStreaming.setVisibility(View.GONE);
+        }
+        updatePublishTime(null, null);
+    }
+
     private void renderNothingAtLocation() {
         Helper.setViewVisibility(layoutLoadingState, View.VISIBLE);
         Helper.setViewVisibility(layoutNothingAtLocation, View.VISIBLE);
@@ -717,6 +753,20 @@ public class FileViewFragment extends BaseFragment implements
         if (textNothingAtLocation != null) {
             textNothingAtLocation.setMovementMethod(LinkMovementMethod.getInstance());
             textNothingAtLocation.setText(HtmlCompat.fromHtml(getString(R.string.dmca_complaint_blocked), HtmlCompat.FROM_HTML_MODE_LEGACY));
+        }
+    }
+
+    private void updatePublishTime(@Nullable Claim.StreamMetadata metadata, @Nullable Claim claim) {
+        View root = getView();
+        if (root != null) {
+            long publishTime = 0;
+            if (metadata != null && claim != null) {
+                publishTime = metadata.getReleaseTime() > 0 ? metadata.getReleaseTime() * 1000 : claim.getTimestamp() * 1000;
+            } else if (claim == null && livestreamStartingMillis != 0){
+                publishTime = livestreamStartingMillis;
+            }
+            ((TextView) root.findViewById(R.id.file_view_publish_time)).setText(DateUtils.getRelativeTimeSpanString(
+                    publishTime, System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
         }
     }
 
@@ -1024,22 +1074,28 @@ public class FileViewFragment extends BaseFragment implements
         if (futureReactions != null) {
             futureReactions.cancel(true);
         }
-        if (futureViewersCount != null) {
-            futureViewersCount.cancel(true);
-        }
         if (futureElapsedPlayback != null) {
             futureElapsedPlayback.cancel(true);
             elapsedPlaybackScheduled = false;
+        }
+        if (scheduledStartPlaying != null) {
+            scheduledStartPlaying.cancel(true);
+        }
+        if (scheduledStopPlaying != null) {
+            scheduledStopPlaying.cancel(true);
         }
 
         if (futureReactions != null && futureReactions.isDone()) {
             futureReactions = null;
         }
-        if (futureViewersCount != null && futureViewersCount.isDone()) {
-            futureViewersCount = null;
-        }
         if (futureElapsedPlayback != null && futureElapsedPlayback.isDone()) {
             futureElapsedPlayback = null;
+        }
+        if (scheduledStartPlaying != null && scheduledStartPlaying.isDone()) {
+            scheduledStartPlaying = null;
+        }
+        if (scheduledStopPlaying != null && scheduledStopPlaying.isDone()) {
+            scheduledStopPlaying = null;
         }
     }
 
@@ -1933,25 +1989,31 @@ public class FileViewFragment extends BaseFragment implements
         if (!claimToRender.hasSource()) {
             Context context = getContext();
             View root = getView();
+            String urlResult = getLivestreamUrl();
             if (claimToRender.getThumbnailUrl() != null && context != null && root != null && !claimToRender.isLive()) {
-                String urlResult = getLivestreamUrl();
                 if (urlResult != null && urlResult.equalsIgnoreCase("notlive")) {
-                    root.findViewById(R.id.file_view_livestream_not_live).setVisibility(View.VISIBLE);
-                    root.findViewById(R.id.file_view_exoplayer_container).setVisibility(View.GONE);
-                    TextView userNotStreaming = root.findViewById(R.id.user_not_streaming);
-                    userNotStreaming.setText(context.getString(R.string.user_not_live_yet, claimToRender.getPublisherName()));
-                    userNotStreaming.setVisibility(View.VISIBLE);
-                    ImageView thumbnailView = root.findViewById(R.id.file_view_livestream_thumbnail);
-                    Glide.with(context.getApplicationContext()).
-                            asBitmap().
-                            load(claimToRender.getThumbnailUrl()).
-                            into(thumbnailView);
+                    renderPublisherNotBroadcasting(claimToRender);
                 } else {
                     fileClaim.setLive(true);
                     fileClaim.setLivestreamUrl(urlResult);
                 }
             }
 
+            if (jsonData != null) {
+                JSONObject j = jsonData.get(fileClaim.getSigningChannel().getClaimId());
+
+                if (j != null && j.has("Start")) {
+                    try {
+                        String livestreamStart = j.getString("Start");
+                        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+                        ZonedDateTime zonedStart = ZonedDateTime.parse(livestreamStart, dtf);
+
+                        livestreamStartingMillis = zonedStart.toInstant().toEpochMilli();
+                    } catch (JSONException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
             // livestream, so we load up the messages and initialise the websocket
             initLivestreamChat();
             isLivestream = true;
@@ -1971,9 +2033,7 @@ public class FileViewFragment extends BaseFragment implements
             Helper.setViewVisibility(tipButton, View.VISIBLE);
 */
 
-        if (fileClaim != null && fileClaim.isLive()) {
-            loadLiveViewersCount(fileClaim);
-        } else {
+        if (fileClaim != null && !fileClaim.isLive()) {
             loadViewCount();
         }
         loadReactions(claimToRender);
@@ -2082,9 +2142,7 @@ public class FileViewFragment extends BaseFragment implements
 
             if (metadata instanceof Claim.StreamMetadata) {
                 Claim.StreamMetadata streamMetadata = (Claim.StreamMetadata) metadata;
-                long publishTime = streamMetadata.getReleaseTime() > 0 ? streamMetadata.getReleaseTime() * 1000 : claimToRender.getTimestamp() * 1000;
-                ((TextView) root.findViewById(R.id.file_view_publish_time)).setText(DateUtils.getRelativeTimeSpanString(
-                        publishTime, System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
+                updatePublishTime(streamMetadata, claimToRender);
 
                 Fee fee = streamMetadata.getFee();
                 if (fee != null && Helper.parseDouble(fee.getAmount(), 0) > 0) {
@@ -2452,13 +2510,12 @@ public class FileViewFragment extends BaseFragment implements
                 ChannelLiveStatus callable = new ChannelLiveStatus(Collections.singletonList(fileClaim.getSigningChannel().getClaimId()));
                 Future<Map<String, JSONObject>> future = ((OdyseeApp) a.getApplication()).getExecutor().submit(callable);
 
-                Map<String, JSONObject> jsonData = future.get();
+                jsonData = future.get();
                 jsonDataUrl = getLivestreamUrl(jsonData.get(fileClaim.getSigningChannel().getClaimId()));
             } catch (InterruptedException | ExecutionException e) {
                 e.printStackTrace();
             }
         }
-
 
         return jsonDataUrl;
     }
@@ -2660,69 +2717,6 @@ public class FileViewFragment extends BaseFragment implements
                 }
             });
             task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-        }
-    }
-
-    private void loadLiveViewersCount(Claim claim) {
-        if (futureViewersCount != null) {
-            futureViewersCount.cancel(true);
-        }
-
-        Activity a = getActivity();
-
-        if (a != null) {
-            Runnable r = () -> {
-                updateLiveViewersCount(claim);
-            };
-            try {
-                futureViewersCount = ((OdyseeApp) a.getApplication()).getScheduledExecutor().scheduleWithFixedDelay(r, 10, 5, TimeUnit.SECONDS);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
-    private void updateLiveViewersCount(Claim claim) {
-        Activity a = getActivity();
-        if (a != null) {
-            Thread t = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    String channelClaimId = claim.getSigningChannel().getClaimId();
-                    Future<Map<String, JSONObject>> futureViewersCount = ((OdyseeApp) a.getApplication()).getExecutor().submit(new ChannelLiveStatus(Collections.singletonList(channelClaimId), false));
-
-                    try {
-                        Map<String, JSONObject> channelStatus = futureViewersCount.get();
-
-                        if (channelStatus.containsKey(channelClaimId)) {
-                            JSONObject jsonData = channelStatus.get(channelClaimId);
-                            if (jsonData != null) {
-                                Integer count = jsonData.getInt("ViewerCount");
-                                a.runOnUiThread(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        try {
-                                            String displayText = getResources().getString(R.string.livestream_view_count, String.valueOf(count));
-                                            View root = getView();
-                                            if (root != null) {
-                                                TextView textViewCount = root.findViewById(R.id.file_view_view_count);
-                                                Helper.setViewText(textViewCount, displayText);
-                                                Helper.setViewVisibility(textViewCount, View.VISIBLE);
-                                            }
-                                        } catch (IllegalStateException ex) {
-                                            ex.printStackTrace();
-                                        }
-                                    }
-                                });
-                            }
-
-                        }
-                    } catch (ExecutionException | InterruptedException | JSONException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            });
-            t.start();
         }
     }
 
@@ -4940,22 +4934,30 @@ public class FileViewFragment extends BaseFragment implements
     private void checkWebSocketClient() {
         Claim actualClaim = collectionClaimItem != null ? collectionClaimItem : fileClaim;
         if ((webSocketClient == null || webSocketClient.isClosed()) && actualClaim != null && !actualClaim.hasSource()) {
-            webSocketClient = new WebSocketClient(new URI(String.format("%s%s", Lbryio.WS_COMMENT_BASE_URL, actualClaim.getClaimId()))) {
+            String signingChannelShort = String.valueOf(LbryUri.parse(actualClaim.getSigningChannel().getCanonicalUrl()).getClaimId());
+            String livechatUrl = String.format("%s%s", Lbryio.WS_COMMENT_BASE_URL, actualClaim.getClaimId());
+            livechatUrl = livechatUrl.concat("&category=").concat(actualClaim.getSigningChannel().getNormalizedName())
+                                     .concat(":").concat(signingChannelShort)
+                                     .concat("&sub_category=viewer");
+            webSocketClient = new WebSocketClient(new URI(livechatUrl)) {
                 @Override
                 public void onOpen(ServerHandshake handshakedata) { }
 
                 @Override
                 public void onMessage(String message) {
+                    Log.i(TAG, "onMessage: ".concat(message));
                     try {
                         JSONObject json = new JSONObject(message);
                         String type = Helper.getJSONString("type", null, json);
-                        if ("delta".equalsIgnoreCase(type)) {
+
+                        if ("delta".equalsIgnoreCase(type) || "viewers".equalsIgnoreCase(type) || "livestream".equalsIgnoreCase(type)) {
                             JSONObject data = Helper.getJSONObject("data", json);
-                            if (data != null) {
+
+                            Activity a = getActivity();
+                            if (data != null && "delta".equalsIgnoreCase(type)) {
                                 JSONObject commentJson = Helper.getJSONObject("comment", data);
                                 if (commentJson != null) {
                                     Comment comment = new Comment();
-                                    Activity a = getActivity();
                                     if (a != null) {
                                         a.runOnUiThread(new Runnable() {
                                             @Override
@@ -4980,10 +4982,95 @@ public class FileViewFragment extends BaseFragment implements
                                         });
                                     }
                                 }
+                            } else if (data != null && "viewers".equalsIgnoreCase(type)) {
+                                int connectedViewers = data.getInt("connected");
+
+                                if (a != null) {
+                                    a.runOnUiThread(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            try {
+                                                Context context = a.getApplicationContext();
+                                                String displayText = context.getResources().getString(R.string.livestream_view_count, String.valueOf(connectedViewers));
+                                                View root = getView();
+                                                if (root != null) {
+                                                    TextView textViewCount = root.findViewById(R.id.file_view_view_count);
+                                                    Helper.setViewText(textViewCount, displayText);
+                                                    Helper.setViewVisibility(textViewCount, View.VISIBLE);
+                                                }
+                                                updatePublishTime(null, null);
+                                            } catch (IllegalStateException ex) {
+                                                ex.printStackTrace();
+                                            }
+                                        }
+                                    });
+                                }
+                            } else if (data != null && "livestream".equalsIgnoreCase(type)) {
+                                DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+                                String liveTime = data.getString("live_time");
+                                String endTime = data.getString("end_time");
+
+                                if (a != null) {
+                                    ZonedDateTime zonedEnd = ZonedDateTime.parse(endTime, dtf);
+                                    ZonedDateTime zonedStart = ZonedDateTime.parse(liveTime, dtf);
+
+                                    if (zonedEnd != null && zonedStart != null) {
+                                        OdyseeApp app = (OdyseeApp) a.getApplication();
+
+                                        Date timeNow = new Date();
+
+                                        long millisecondsEnd = zonedEnd.toInstant().toEpochMilli();
+                                        long deltaEnd = millisecondsEnd - timeNow.getTime();
+
+                                        if (deltaEnd > 0) {
+                                            scheduledStopPlaying = app.getScheduledExecutor().schedule(new Runnable() {
+                                                @Override
+                                                public void run() {
+                                                    a.runOnUiThread(new Runnable() {
+                                                        @Override
+                                                        public void run() {
+                                                            MainActivity.appPlayer.stop();
+                                                            livestreamStartingMillis = 0;
+                                                            renderPublisherNotBroadcasting(actualClaim);
+                                                        }
+                                                    });
+                                                }
+                                            }, deltaEnd, TimeUnit.MILLISECONDS);
+                                        }
+
+                                        long millisecondsStart = zonedStart.toInstant().toEpochMilli();
+                                        livestreamStartingMillis = millisecondsStart;
+                                        updatePublishTime(null, null);
+                                        long deltaStart = millisecondsStart - timeNow.getTime();
+
+                                        if (deltaStart > 0) {
+                                            scheduledStartPlaying = app.getScheduledExecutor().schedule(new Runnable() {
+                                                @Override
+                                                public void run() {
+                                                    a.runOnUiThread(new Runnable() {
+                                                        @Override
+                                                        public void run() {
+                                                            JSONObject jsonResult = jsonData.get(fileClaim.getSigningChannel().getClaimId());
+                                                            if (jsonResult != null && jsonResult.has("VideoURL")) {
+                                                                try {
+                                                                    claimLivestreamUrl = jsonResult.getString("VideoURL");
+                                                                    renderPublisherBroadcasting();
+                                                                    playMedia();
+                                                                } catch (JSONException e) {
+                                                                    e.printStackTrace();
+                                                                }
+                                                            }
+                                                        }
+                                                    });
+                                                }
+                                            }, deltaStart, TimeUnit.MILLISECONDS);
+                                        }
+                                    }
+                                }
                             }
                         }
                     } catch (JSONException ex) {
-                        // pass
+                        ex.printStackTrace();
                     }
                 }
 

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -777,7 +777,7 @@ public class FollowingFragment extends BaseFragment implements
                 while (it.hasNext()) {
                     Map.Entry<String, JSONObject> pair = it.next();
                     JSONObject j = pair.getValue();
-                    String activeClaimId = null;
+                    String activeClaimId;
                     if (j.has("ActiveClaim")) {
                         JSONObject activeJson = (JSONObject) j.get("ActiveClaim");
                         activeClaimId = activeJson.getString("ClaimID");

--- a/app/src/main/java/com/odysee/app/utils/Lbryio.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbryio.java
@@ -57,7 +57,7 @@ public final class Lbryio {
     public static final String TAG = "OdyseeUA";
     public static final String CONNECTION_STRING = "https://api.lbry.com";
     public static final String WS_CONNECTION_BASE_URL = "wss://api.odysee.com/subscribe?auth_token=";
-    public static final String WS_COMMENT_BASE_URL = "wss://comments.odysee.com/api/v2/live-chat/subscribe?subscription_id=";
+    public static final String WS_COMMENT_BASE_URL = "wss://sockety.odysee.tv/ws/commentron?id=";
     public static final String AUTH_TOKEN_PARAM = "auth_token";
     public static List<Subscription> subscriptions = new ArrayList<>();
     public static List<Claim> cacheResolvedSubscriptions = new ArrayList<>();


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number:

## What is the current behavior?
Time to start or stop playing a livestream is broadcasted via the chat websocket. Currently, these data is not used
## What is the new behavior?
Livestream will be scheduled to start or stop being played at the expected time
## Other information
To test this, I used the same code would be executed on the scheduled future, so it runs in a few minutes after running the app, to ensure I was able to get to some regular livestream. The livestream stop at the time I set. Once a start or stop event arrives, the same code would run and will provide same results.
