### PR TITLE
Fix infinite recursion on ChannelCreateDialog showError method

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelCreateDialogFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelCreateDialogFragment.java
@@ -205,7 +205,8 @@ public class ChannelCreateDialogFragment extends BottomSheetDialogFragment {
             activity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    showError(message);
+                    activity.showError(message);
+                    dismiss();
                 }
             });
         }


### PR DESCRIPTION
Call showError on MainActivity and dismiss dialog instead.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Regression in #196

## What is the current behavior?

When an error is shown in ChannelCreateDialogFragment app crashes due to infinite recursion

## What is the new behavior?

Snackbar properly shown and dialog dismissed.
