### PR TITLE
Use SimpleMenuPreference library for better dark mode contrast

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'androidx.preference:preference:1.1.1'
+    implementation 'com.takisoft.preferencex:preferencex-simplemenu:1.1.0'
     implementation 'androidx.webkit:webkit:1.4.0'
     implementation 'androidx.camera:camera-core:1.1.0-beta03'
     implementation 'androidx.camera:camera-camera2:1.1.0-beta03'

--- a/app/src/main/res/xml-v29/settings.xml
+++ b/app/src/main/res/xml-v29/settings.xml
@@ -18,7 +18,7 @@
             app:title="@string/enable_background_playback_pip_mode"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:key="com.odysee.app.preference.userinterface.AutoplayMedia"
             app:entries="@array/media_autoplay"
             app:entryValues="@array/media_autoplay_values"
@@ -27,25 +27,25 @@
             app:summary="%s"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:key="com.odysee.app.preference.userinterface.WifiDefaultQuality"
             app:entries="@array/available_qualities"
             app:entryValues="@array/available_qualities_values"
-            app:defaultValue="@string/auto_quality"
+            app:defaultValue="0"
             app:title="@string/wifi_default_quality"
             app:singleLineTitle="false"
             app:summary="%s"
             app:iconSpaceReserved="false" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:key="com.odysee.app.preference.userinterface.MobileDefaultQuality"
             app:entries="@array/available_qualities"
             app:entryValues="@array/available_qualities_values"
-            app:defaultValue="@string/auto_quality"
+            app:defaultValue="0"
             app:title="@string/mobile_default_quality"
             app:singleLineTitle="false"
             app:summary="%s"
             app:iconSpaceReserved="false" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:defaultValue="100"
             app:entries="@array/available_speeds"
             app:entryValues="@array/available_speeds_values"
@@ -54,7 +54,7 @@
             app:singleLineTitle="false"
             app:summary="%s"
             app:title="@string/playback_default_speed" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:key="com.odysee.app.preference.userinterface.DarkModeSetting"
             app:defaultValue="system"
             app:entries="@array/darkmode_setting_labels"

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -18,7 +18,7 @@
             app:title="@string/enable_background_playback_pip_mode"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:key="com.odysee.app.preference.userinterface.AutoplayMedia"
             app:entries="@array/media_autoplay"
             app:entryValues="@array/media_autoplay_values"
@@ -27,25 +27,25 @@
             app:summary="%s"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:key="com.odysee.app.preference.userinterface.WifiDefaultQuality"
             app:entries="@array/available_qualities"
             app:entryValues="@array/available_qualities_values"
-            app:defaultValue="@string/auto_quality"
+            app:defaultValue="0"
             app:title="@string/wifi_default_quality"
             app:singleLineTitle="false"
             app:summary="%s"
             app:iconSpaceReserved="false" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:key="com.odysee.app.preference.userinterface.MobileDefaultQuality"
             app:entries="@array/available_qualities"
             app:entryValues="@array/available_qualities_values"
-            app:defaultValue="@string/auto_quality"
+            app:defaultValue="0"
             app:title="@string/mobile_default_quality"
             app:singleLineTitle="false"
             app:summary="%s"
             app:iconSpaceReserved="false" />
-        <DropDownPreference
+        <com.takisoft.preferencex.SimpleMenuPreference
             app:defaultValue="100"
             app:entries="@array/available_speeds"
             app:entryValues="@array/available_speeds_values"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: N/A

## What is the current behavior?

In dark mode, the drop down menus in App Settings have the same background color as the app, so it is hard to distinguish.

## What is the new behavior?

SimpleMenuPreference uses a gray background color.

|Before|After|
|--|--|
|<img src="https://user-images.githubusercontent.com/71804605/174704605-83de4785-bfae-464e-970e-cfe279b0b8ea.jpg">|<img src="https://user-images.githubusercontent.com/71804605/174704638-40cb4fa5-5b79-4b44-8a20-ede4939c0d84.jpg">|
