### PR TITLE
Allow to set a default channel used to interact with the platform

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -1025,13 +1025,31 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                             params.height = listHeight + (defaultChannelList.getCount() + 1) * defaultChannelList.getDividerHeight();
                             defaultChannelList.setLayoutParams(params);
                             defaultChannelList.setVerticalScrollBarEnabled(false);
+                            TransitionManager.beginDelayedTransition((ViewGroup) popupWindow.getContentView());
                             defaultChannelList.requestLayout();
 
-                            TransitionManager.beginDelayedTransition((ViewGroup) popupWindow.getContentView());
+                            buttonChannels.setVisibility(View.GONE);
+                            buttonGoLive.setVisibility(View.GONE);
+                            buttonPublishes.setVisibility(View.GONE);
+                            buttonShowRewards.setVisibility(View.GONE);
+                            customView.findViewById(R.id.button_help_support).setVisibility(View.GONE);
+                            customView.findViewById(R.id.button_app_settings).setVisibility(View.GONE);
+                            customView.findViewById(R.id.button_community_guidelines).setVisibility(View.GONE);
+                            buttonSignOut.setVisibility(View.GONE);
+                            buttonYouTubeSync.setVisibility(View.GONE);
                             defaultChannelListParent.setVisibility(View.VISIBLE);
                             ((ImageView) buttonChangeDefaultChannel.findViewById(R.id.expandable)).setImageDrawable(ctx.getResources().getDrawable(R.drawable.ic_arrow_dropup, getTheme()));
                         } else {
                             TransitionManager.beginDelayedTransition((ViewGroup) popupWindow.getContentView());
+                            buttonChannels.setVisibility(View.VISIBLE);
+                            buttonGoLive.setVisibility(View.VISIBLE);
+                            buttonPublishes.setVisibility(View.VISIBLE);
+                            buttonShowRewards.setVisibility(View.VISIBLE);
+                            customView.findViewById(R.id.button_help_support).setVisibility(View.VISIBLE);
+                            customView.findViewById(R.id.button_app_settings).setVisibility(View.VISIBLE);
+                            customView.findViewById(R.id.button_community_guidelines).setVisibility(View.VISIBLE);
+                            buttonSignOut.setVisibility(View.VISIBLE);
+                            buttonYouTubeSync.setVisibility(View.VISIBLE);
                             defaultChannelListParent.setVisibility(View.GONE);
                             ((ImageView) buttonChangeDefaultChannel.findViewById(R.id.expandable)).setImageDrawable(ctx.getResources().getDrawable(R.drawable.ic_arrow_dropdown, getTheme()));
                         }

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -943,11 +943,18 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     userIdText.setVisibility(View.VISIBLE);
                     signUserButton.setVisibility(View.GONE);
                     userIdText.setText(am.getUserData(odyseeAccount, "email"));
+
+                    if (Lbry.ownChannels.size() > 0) {
+                        buttonChangeDefaultChannel.setVisibility(View.VISIBLE);
+                    } else {
+                        buttonChangeDefaultChannel.setVisibility(View.GONE);
+                    }
                 } else {
                     userIdText.setVisibility(View.GONE);
                     userIdText.setText("");
                     signUserButton.setVisibility(View.VISIBLE);
                     signUserButton.setText(getString(R.string.sign_up_log_in));
+                    buttonChangeDefaultChannel.setVisibility(View.GONE);
                 }
 
                 customView.findViewById(R.id.button_app_settings).setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -43,6 +43,7 @@ import android.text.SpannableString;
 import android.text.TextWatcher;
 import android.text.style.TypefaceSpan;
 import android.transition.Slide;
+import android.transition.TransitionManager;
 import android.util.Base64;
 import android.util.Log;
 import android.view.Gravity;
@@ -60,6 +61,7 @@ import android.view.animation.DecelerateInterpolator;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebView;
+import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
@@ -121,6 +123,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import com.odysee.app.adapter.ProfileDefaultChannelAdapter;
 import com.odysee.app.callable.WalletBalanceFetch;
 import com.odysee.app.dialog.AddToListsDialogFragment;
 import com.odysee.app.model.OdyseeCollection;
@@ -167,6 +170,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
@@ -912,6 +916,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 });
                 MaterialButton signUserButton = customView.findViewById(R.id.button_sign_user);
 
+                View buttonChangeDefaultChannel = customView.findViewById(R.id.button_change_default_channel);
+                View defaultChannelListParent = customView.findViewById(R.id.default_channel_list_layout);
+                ListView defaultChannelList = customView.findViewById(R.id.default_channel_list);
                 View buttonGoLive = customView.findViewById(R.id.button_go_live);
                 View buttonChannels = customView.findViewById(R.id.button_channels);
                 View buttonPublishes = customView.findViewById(R.id.button_publishes);
@@ -981,6 +988,56 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder().setDefaultColorSchemeParams(ctcsp);
                         CustomTabsIntent intent = builder.build();
                         intent.launchUrl(MainActivity.this, Uri.parse("https://odysee.com/@OdyseeHelp:b?view=about"));
+                    }
+                });
+
+                buttonChangeDefaultChannel.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (defaultChannelListParent.getVisibility() == View.GONE) {
+                            int listHeight = Math.round(getResources().getDisplayMetrics().density);
+                            List<String> ownChannels = Lbry.ownChannels.stream().map(Claim::getName).filter(name -> name != null).collect(Collectors.toList());
+                            ProfileDefaultChannelAdapter adapter = new ProfileDefaultChannelAdapter(ctx, ownChannels);
+
+                            defaultChannelList.setAdapter(adapter);
+
+                            String defaultChannel = Helper.getDefaultChannelName(ctx);
+
+                            if (defaultChannel != null) {
+                                adapter.setDefaultChannelName(defaultChannel);
+                            }
+
+                            for (int i = 0; i < ownChannels.size(); i++) {
+                                View item = adapter.getView(i, null, defaultChannelList);
+                                item.measure(0, 0);
+                                listHeight += item.getMeasuredHeight();
+                            }
+
+                            // Avoid scroll bars being displayed
+                            ViewGroup.LayoutParams params = defaultChannelList.getLayoutParams();
+                            params.height = listHeight + (defaultChannelList.getCount() + 1) * defaultChannelList.getDividerHeight();
+                            defaultChannelList.setLayoutParams(params);
+                            defaultChannelList.setVerticalScrollBarEnabled(false);
+                            defaultChannelList.requestLayout();
+
+                            TransitionManager.beginDelayedTransition((ViewGroup) popupWindow.getContentView());
+                            defaultChannelListParent.setVisibility(View.VISIBLE);
+                            ((ImageView) buttonChangeDefaultChannel.findViewById(R.id.expandable)).setImageDrawable(ctx.getResources().getDrawable(R.drawable.ic_arrow_dropup, getTheme()));
+                        } else {
+                            TransitionManager.beginDelayedTransition((ViewGroup) popupWindow.getContentView());
+                            defaultChannelListParent.setVisibility(View.GONE);
+                            ((ImageView) buttonChangeDefaultChannel.findViewById(R.id.expandable)).setImageDrawable(ctx.getResources().getDrawable(R.drawable.ic_arrow_dropdown, getTheme()));
+                        }
+                    }
+                });
+
+                defaultChannelList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                    @Override
+                    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                        String defaultChannelName = (String) defaultChannelList.getAdapter().getItem(position);
+                        AccountManager am = AccountManager.get(ctx);
+                        am.setUserData(Helper.getOdyseeAccount(am.getAccounts()), "default_channel_name", defaultChannelName);
+                        ((ProfileDefaultChannelAdapter)defaultChannelList.getAdapter()).setDefaultChannelName(defaultChannelName);
                     }
                 });
 

--- a/app/src/main/java/com/odysee/app/adapter/ProfileDefaultChannelAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ProfileDefaultChannelAdapter.java
@@ -1,7 +1,6 @@
 package com.odysee.app.adapter;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -9,12 +8,11 @@ import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
 import com.odysee.app.R;
-import com.odysee.app.model.StartupStage;
 
 import java.util.List;
 
 public class ProfileDefaultChannelAdapter extends BaseAdapter {
-    private List<String> list;
+    private final List<String> list;
     private int defaultItem;
     private final LayoutInflater inflater;
 

--- a/app/src/main/java/com/odysee/app/adapter/ProfileDefaultChannelAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ProfileDefaultChannelAdapter.java
@@ -1,0 +1,63 @@
+package com.odysee.app.adapter;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ImageView;
+import android.widget.TextView;
+import com.odysee.app.R;
+import com.odysee.app.model.StartupStage;
+
+import java.util.List;
+
+public class ProfileDefaultChannelAdapter extends BaseAdapter {
+    private List<String> list;
+    private int defaultItem;
+    private final LayoutInflater inflater;
+
+    public ProfileDefaultChannelAdapter(Context ctx, List<String> rows) {
+        this.list = rows;
+        this.inflater = LayoutInflater.from(ctx);
+    }
+    @Override
+    public int getCount() {
+        return list.size();
+    }
+
+    @Override
+    public Object getItem(int i) {
+        return list.get(i);
+    }
+
+    @Override
+    public long getItemId(int i) {
+        return i;
+    }
+
+    @Override
+    public View getView(int i, View view, ViewGroup viewGroup) {
+        if (view == null) {
+            view = inflater.inflate(R.layout.list_item_profile_popup_channel, viewGroup, false);
+        }
+
+        ImageView selectedImage = view.findViewById(R.id.selected_image);
+
+        if (defaultItem == i) {
+            selectedImage.setVisibility(View.VISIBLE);
+        } else {
+            selectedImage.setVisibility(View.INVISIBLE);
+        }
+
+        TextView channelName = view.findViewById(R.id.popup_channel_name);
+        channelName.setText(list.get(i));
+        return view;
+    }
+
+    public void setDefaultChannelName(String name) {
+        defaultItem = list.indexOf(name);
+        notifyDataSetChanged();
+    }
+}

--- a/app/src/main/java/com/odysee/app/dialog/CreateSupportDialogFragment.java
+++ b/app/src/main/java/com/odysee/app/dialog/CreateSupportDialogFragment.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import com.odysee.app.MainActivity;
 import com.odysee.app.R;
@@ -377,8 +378,8 @@ public class CreateSupportDialogFragment extends BottomSheetDialogFragment imple
     }
 
     private void updateChannelList(List<Claim> channels) {
+        Context context = getContext();
         if (channelSpinnerAdapter == null) {
-            Context context = getContext();
             if (context != null) {
                 channelSpinnerAdapter = new InlineChannelSpinnerAdapter(context, R.layout.spinner_item_channel, new ArrayList<>(channels));
                 channelSpinnerAdapter.addAnonymousPlaceholder();
@@ -397,7 +398,14 @@ public class CreateSupportDialogFragment extends BottomSheetDialogFragment imple
 
         if (channelSpinnerAdapter != null && channelSpinner != null) {
             if (channelSpinnerAdapter.getCount() > 1) {
-                channelSpinner.setSelection(1);
+                String defaultChannelName = Helper.getDefaultChannelName(context);
+                List<Claim> defaultChannel = channels.stream().filter(c -> c != null && c.getName().equalsIgnoreCase(defaultChannelName)).collect(Collectors.toList());
+
+                if (defaultChannel.size() > 0) {
+                    channelSpinner.setSelection(channelSpinnerAdapter.getItemPosition(defaultChannel.get(0)));
+                } else {
+                    channelSpinner.setSelection(1);
+                }
             }
         }
     }

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelCommentsFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelCommentsFragment.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.odysee.app.BuildConfig;
 import com.odysee.app.MainActivity;
@@ -382,8 +383,8 @@ public class ChannelCommentsFragment extends BaseFragment implements ChannelCrea
     }
 
     private void updateChannelList(List<Claim> channels) {
+        Context context = getContext();
         if (commentChannelSpinnerAdapter == null) {
-            Context context = getContext();
             if (context != null) {
                 commentChannelSpinnerAdapter = new InlineChannelSpinnerAdapter(context, R.layout.spinner_item_channel, new ArrayList<>(channels));
                 commentChannelSpinnerAdapter.addPlaceholder(false);
@@ -402,7 +403,15 @@ public class ChannelCommentsFragment extends BaseFragment implements ChannelCrea
 
         if (commentChannelSpinnerAdapter != null && commentChannelSpinner != null) {
             if (commentChannelSpinnerAdapter.getCount() > 1) {
-                commentChannelSpinner.setSelection(1);
+                String defaultChannelName = Helper.getDefaultChannelName(context);
+
+                List<Claim> defaultChannel = channels.stream().filter(c -> c != null && c.getName().equalsIgnoreCase(defaultChannelName)).collect(Collectors.toList());
+
+                if (defaultChannel.size() > 0) {
+                    commentChannelSpinner.setSelection(commentChannelSpinnerAdapter.getItemPosition(defaultChannel.get(0)));
+                } else {
+                    commentChannelSpinner.setSelection(1);
+                }
             }
         }
     }

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -4497,8 +4497,8 @@ public class FileViewFragment extends BaseFragment implements
     }
 
     private void updateChannelList(List<Claim> channels) {
+        Context context = getContext();
         if (commentChannelSpinnerAdapter == null) {
-            Context context = getContext();
             if (context != null) {
                 commentChannelSpinnerAdapter = new InlineChannelSpinnerAdapter(context, R.layout.spinner_item_channel, new ArrayList<>(channels));
                 commentChannelSpinnerAdapter.addPlaceholder(false);
@@ -4517,7 +4517,14 @@ public class FileViewFragment extends BaseFragment implements
 
         if (commentChannelSpinnerAdapter != null && commentChannelSpinner != null) {
             if (commentChannelSpinnerAdapter.getCount() > 1) {
-                commentChannelSpinner.setSelection(1);
+                String defaultChannelName = Helper.getDefaultChannelName(context);
+                List<Claim> defaultChannel = channels.stream().filter(c -> c != null && c.getName().equalsIgnoreCase(defaultChannelName)).collect(Collectors.toList());
+
+                if (defaultChannel.size() > 0) {
+                    commentChannelSpinner.setSelection(commentChannelSpinnerAdapter.getItemPosition(defaultChannel.get(0)));
+                } else {
+                    commentChannelSpinner.setSelection(1);
+                }
             }
         }
     }

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
@@ -51,6 +51,7 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import com.odysee.app.BuildConfig;
 import com.odysee.app.MainActivity;
@@ -911,8 +912,8 @@ public class PublishFormFragment extends BaseFragment implements
     }
 
     private void updateChannelList(List<Claim> channels) {
+        Context context = getContext();
         if (channelSpinnerAdapter == null) {
-            Context context = getContext();
             if (context != null) {
                 channelSpinnerAdapter = new InlineChannelSpinnerAdapter(context, R.layout.spinner_item_channel, new ArrayList<>(channels));
                 channelSpinnerAdapter.addPlaceholder(true);
@@ -941,7 +942,15 @@ public class PublishFormFragment extends BaseFragment implements
             } else {
                 if (channelSpinnerAdapter.getCount() > 2) {
                     // if anonymous displayed, select first channel if available
-                    channelSpinner.setSelection(2);
+                    String defaultChannelName = Helper.getDefaultChannelName(context);
+
+                    List<Claim> defaultChannel = channels.stream().filter(c -> c != null && c.getName().equalsIgnoreCase(defaultChannelName)).collect(Collectors.toList());
+
+                    if (defaultChannel.size() > 0) {
+                        channelSpinner.setSelection(channelSpinnerAdapter.getItemPosition(defaultChannel.get(0)));
+                    } else {
+                        channelSpinner.setSelection(2);
+                    }
                 } else if (channelSpinnerAdapter.getCount() > 1) {
                     // select anonymous
                     channelSpinner.setSelection(1);

--- a/app/src/main/java/com/odysee/app/ui/wallet/InvitesFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/wallet/InvitesFragment.java
@@ -1,5 +1,6 @@
 package com.odysee.app.ui.wallet;
 
+import android.accounts.AccountManager;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.odysee.app.MainActivity;
 import com.odysee.app.R;
@@ -244,8 +246,8 @@ public class InvitesFragment extends BaseFragment implements WalletBalanceListen
     }
 
     private void updateChannelList(List<Claim> channels) {
+        Context context = getContext();
         if (channelSpinnerAdapter == null) {
-            Context context = getContext();
             channelSpinnerAdapter = new InlineChannelSpinnerAdapter(context, R.layout.spinner_item_channel, new ArrayList<>(channels));
         } else {
             channelSpinnerAdapter.clear();
@@ -260,7 +262,14 @@ public class InvitesFragment extends BaseFragment implements WalletBalanceListen
         }
 
         if (channelSpinnerAdapter.getCount() > 1) {
-            channelSpinner.setSelection(1);
+            String defaultChannelName = Helper.getDefaultChannelName(context);
+            List<Claim> defaultChannel = channels.stream().filter(c -> c != null && c.getName().equalsIgnoreCase(defaultChannelName)).collect(Collectors.toList());
+
+            if (defaultChannel.size() > 0) {
+                channelSpinner.setSelection(channelSpinnerAdapter.getItemPosition(defaultChannel.get(0)));
+            } else {
+                channelSpinner.setSelection(1);
+            }
         }
     }
 

--- a/app/src/main/java/com/odysee/app/utils/Helper.java
+++ b/app/src/main/java/com/odysee/app/utils/Helper.java
@@ -1,8 +1,8 @@
 package com.odysee.app.utils;
 
 import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.annotation.SuppressLint;
-import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.ContentUris;
 import android.content.Context;
@@ -41,7 +41,6 @@ import org.json.JSONObject;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
@@ -974,6 +973,18 @@ public final class Helper {
             }
         }
         return null;
+    }
+
+    /**
+     * Get the channel name which current user set as its default
+     * @param ctx Android context
+     * @return a string with the channel name including the '@'. It could return null if not set
+     */
+    public static String getDefaultChannelName(Context ctx) {
+        AccountManager am = AccountManager.get(ctx);
+        String defaultChannelName = am.getUserData(Helper.getOdyseeAccount(am.getAccounts()), "default_channel_name");
+
+        return defaultChannelName;
     }
 
     public static int getDimenAsPixels(Context context, final int dimenId) {

--- a/app/src/main/res/layout/list_item_profile_popup_channel.xml
+++ b/app/src/main/res/layout/list_item_profile_popup_channel.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
+                                                   xmlns:tools="http://schemas.android.com/tools"
+                                                   android:layout_width="match_parent"
+                                                   android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/selected_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minHeight="48dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:src="@drawable/ic_circle_checked"
+        app:tint="@color/odyseePink"
+        android:paddingEnd="8dp"
+        android:visibility="invisible"
+        tools:visibility="visible"/>
+    <TextView
+        android:id="@+id/popup_channel_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:minHeight="48dp"
+        tools:text="\@TestChannel"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/selected_image"
+        app:layout_constraintTop_toTopOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/popup_user.xml
+++ b/app/src/main/res/layout/popup_user.xml
@@ -15,12 +15,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
             android:orientation="horizontal">
             <ImageButton
-                android:layout_width="24dp"
-                android:layout_height="24dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:id="@+id/popup_user_close_button"
                 android:src="@drawable/ic_close"
                 android:background="@drawable/flag_transparent"
@@ -29,12 +27,12 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="8dp"
-                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
                 android:id="@+id/user_id"
                 android:textStyle="bold"
                 android:textSize="16sp"
                 android:visibility="gone"
+                android:layout_gravity="center_vertical"
                 android:singleLine="true"
                 android:ellipsize="middle"
                 tools:text="user@example.com"
@@ -54,22 +52,61 @@
             android:text="@string/sign_up_log_in"/>
 
         <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:id="@+id/button_change_default_channel"
+            android:clickable="true"
+            android:focusable="true"
+            android:focusableInTouchMode="false"
+            android:background="?android:selectableItemBackground"
+            android:layout_marginTop="8dp"
+            android:paddingEnd="8dp">
+            <TextView
+                android:layout_marginStart="40dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:text="@string/change_default_channel"
+                android:textSize="14sp" />
+            <ImageView
+                android:id="@+id/expandable"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:src="@drawable/ic_arrow_dropdown"
+                app:tint="@color/foreground" />
+        </RelativeLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/default_channel_list_layout"
+            android:layout_marginStart="40dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+            <ListView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/default_channel_list"
+                tools:listitem="@layout/list_item_profile_popup_channel"/>
+        </LinearLayout>
+
+        <RelativeLayout
             android:clickable="true"
             android:focusable="true"
             android:focusableInTouchMode="false"
             android:id="@+id/button_go_live"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp"
-            android:layout_marginTop="8dp">
+            android:layout_height="48dp">
             <TextView
-                android:layout_marginLeft="40dp"
-                android:layout_marginStart="40dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
+                android:layout_marginStart="40dp"
                 android:text="@string/go_live"
-                android:textSize="14sp" />
+                android:textSize="14sp"/>
         </RelativeLayout>
 
         <RelativeLayout
@@ -79,9 +116,8 @@
             android:id="@+id/button_channels"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp">
+            android:layout_height="48dp">
             <TextView
-                android:layout_marginLeft="40dp"
                 android:layout_marginStart="40dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -97,9 +133,8 @@
             android:id="@+id/button_publishes"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp">
+            android:layout_height="48dp">
             <TextView
-                android:layout_marginLeft="40dp"
                 android:layout_marginStart="40dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -115,13 +150,12 @@
             android:id="@+id/button_show_rewards"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp">
+            android:layout_height="48dp">
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_marginStart="40dp"
-                android:layout_marginLeft="40dp"
                 android:text="@string/rewards"
                 android:textSize="14sp" />
         </RelativeLayout>
@@ -133,13 +167,12 @@
             android:id="@+id/button_youtube_sync"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp">
+            android:layout_height="48dp">
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_marginStart="40dp"
-                android:layout_marginLeft="40dp"
                 android:text="@string/youtube_sync"
                 android:textSize="14sp" />
         </RelativeLayout>
@@ -151,14 +184,13 @@
             android:id="@+id/button_app_settings"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp">
+            android:layout_height="48dp">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_marginStart="40dp"
-                android:layout_marginLeft="40dp"
                 android:text="@string/app_settings"
                 android:textSize="14sp" />
         </RelativeLayout>
@@ -170,14 +202,13 @@
             android:id="@+id/button_community_guidelines"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp">
+            android:layout_height="48dp">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_marginStart="40dp"
-                android:layout_marginLeft="40dp"
                 android:text="@string/community_guidelines"
                 android:textSize="14sp" />
         </RelativeLayout>
@@ -189,13 +220,12 @@
             android:id="@+id/button_help_support"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp">
+            android:layout_height="48dp">
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_marginStart="40dp"
-                android:layout_marginLeft="40dp"
                 android:text="@string/help_and_support"
                 android:textSize="14sp" />
         </RelativeLayout>
@@ -207,12 +237,10 @@
             android:id="@+id/button_sign_out"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
-            android:layout_height="40dp"
-            android:layout_marginBottom="8dp">
+            android:layout_height="48dp">
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="40dp"
                 android:layout_marginStart="40dp"
                 android:layout_centerVertical="true"
                 android:text="@string/sign_out"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="editors_choice">Editor\'s Choice</string>
     <string name="your_tags">Your Tags</string>
     <string name="all_content">All Content</string>
+    <string name="change_default_channel">Change default channel</string>
     <string name="go_live">Go Live</string>
     <string name="channels">Channels</string>
     <string name="library">Library</string>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: UI part for #230 

## What is the current behavior?
User cannot set a channel which app could select by default when one is needed
## What is the new behavior?
User is able to set a channel which will always be selected by default when commenting, tipping/supporting or publishing some content.
## Other information
The default channel name is stored as user data. This means it is stored along the Android account. This will make it be deleted when user account is removed from the device. No longer having to make the cleanup when user signs out.