### PR TITLE
Show publish time for non-active livetsream claim

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -320,7 +320,7 @@ public class FileViewFragment extends BaseFragment implements
     ScheduledFuture<?> futureElapsedPlayback;
     ScheduledFuture<?> scheduledStartPlaying;
     ScheduledFuture<?> scheduledStopPlaying;
-    private long livestreamStartingMillis = 0;
+    private long livestreamStartingMillis = 0; // Stores the time when livestream will start or when it started
 
     private boolean postingComment;
     private boolean fetchingChannels;
@@ -723,7 +723,7 @@ public class FileViewFragment extends BaseFragment implements
                     load(claimToRender.getThumbnailUrl()).
                     into(thumbnailView);
         }
-        updatePublishTime(null, claimToRender);
+        updatePublishTime((Claim.StreamMetadata)claimToRender.getValue(), claimToRender);
     }
 
     private void renderPublisherBroadcasting() {
@@ -5006,7 +5006,11 @@ public class FileViewFragment extends BaseFragment implements
                                                     Helper.setViewText(textViewCount, displayText);
                                                     Helper.setViewVisibility(textViewCount, View.VISIBLE);
                                                 }
-                                                updatePublishTime(null, null);
+                                                if (livestreamStartingMillis != 0) {
+                                                    updatePublishTime(null, null);
+                                                } else { // Broadcast has not started or has finished
+                                                    updatePublishTime((Claim.StreamMetadata) actualClaim.getValue(), actualClaim);
+                                                }
                                             } catch (IllegalStateException ex) {
                                                 ex.printStackTrace();
                                             }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Claims which are of type livestream but are not broadcasting now or will start in the future are showing a date corresponding to 0 in milliseconds
## What is the new behavior?
Now they will show claim's release time