### PR TITLE
Remove duplicate livestream claim from regular claims on channel content

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
@@ -318,8 +318,8 @@ public class ChannelContentFragment extends Fragment implements DownloadActionLi
                         List<Claim> liveItems = items.stream().filter(e -> e != null && e.isHighlightLive()).collect(Collectors.toList());
                         List<Claim> regularItems = items.stream().filter(e -> e != null && !e.isHighlightLive()).collect(Collectors.toList());
 
-                        for (Claim c : regularItems) {
-                            liveItems.removeIf(e -> e.getClaimId().equalsIgnoreCase(c.getClaimId()));
+                        for (Claim c : liveItems) {
+                            regularItems.removeIf(e -> e.getClaimId().equalsIgnoreCase(c.getClaimId()));
                         }
 
                         regularItems.removeIf(c -> {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
some channels with active livestreams aren't showing any on its content page
## What is the new behavior?
Active livestream is being listed