### PR TITLE
Update Like/Dislike count/color immediately when reacting

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -5071,6 +5071,10 @@ public class FileViewFragment extends BaseFragment implements
                 futureReactions.cancel(true);
             }
 
+            reactions.setLiked(like && !reactions.isLiked());
+            reactions.setDisliked(!like && !reactions.isDisliked());
+            updateContentReactions();
+
             Map<String, String> options = new HashMap<>();
             options.put("claim_ids", claim.getClaimId());
             options.put("type", like ? "like" : "dislike");
@@ -5081,15 +5085,14 @@ public class FileViewFragment extends BaseFragment implements
             }
 
             try {
-                JSONObject jsonResponse = (JSONObject) Lbryio.parseResponse(Lbryio.call("reaction", "react", options, Helper.METHOD_POST, getContext()));
-
-                if (jsonResponse != null && jsonResponse.has(claim.getClaimId())) {
-                    reactions.setLiked(jsonResponse.getJSONObject(claim.getClaimId()).has("like") && !reactions.isLiked());
-                    reactions.setDisliked(jsonResponse.getJSONObject(claim.getClaimId()).has("dislike") && !reactions.isDisliked());
-                    updateContentReactions();
-                }
-            } catch (LbryioRequestException | LbryioResponseException | JSONException e) {
+                Lbryio.call("reaction", "react", options, Helper.METHOD_POST, getContext());
+            } catch (LbryioRequestException | LbryioResponseException e) {
                 e.printStackTrace();
+
+                // Reset reactions to original values on error
+                reactions.setLiked(like && !reactions.isLiked());
+                reactions.setDisliked(!like && !reactions.isDisliked());
+                updateContentReactions();
             } finally {
                 loadReactions(claim);
             }


### PR DESCRIPTION
Reset to original values if react fails.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: N/A

## What is the current behavior?

Reaction button color and count only changes after react call completes, with no user feedback in the meantime.

## What is the new behavior?

Reaction button color and count changes immediately.
Resets to old value if react call fails.
