### PR TITLE
Bump ExoPlayer to 2.18.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,12 +103,12 @@ dependencies {
     fullImplementation 'com.android.billingclient:billing:3.0.2'
 
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.16.0'
-    implementation 'com.google.android.exoplayer:exoplayer-dash:2.16.0'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.16.0'
-    implementation 'com.google.android.exoplayer:extension-mediasession:2.16.0'
-    implementation 'com.google.android.exoplayer:exoplayer-hls:2.16.0'
 //    fullImplementation 'com.google.android.exoplayer:extension-cast:2.16.0'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.18.1'
+    implementation 'com.google.android.exoplayer:exoplayer-dash:2.18.1'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.18.1'
+    implementation 'com.google.android.exoplayer:extension-mediasession:2.18.1'
+    implementation 'com.google.android.exoplayer:exoplayer-hls:2.18.1'
 
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
 

--- a/app/src/main/java/com/odysee/app/utils/Helper.java
+++ b/app/src/main/java/com/odysee/app/utils/Helper.java
@@ -56,9 +56,7 @@ import java.util.Random;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.TracksInfo;
-import com.google.android.exoplayer2.TracksInfo.TrackGroupInfo;
-import com.google.android.exoplayer2.source.TrackGroup;
+import com.google.android.exoplayer2.Tracks;
 import com.odysee.app.MainActivity;
 import com.odysee.app.R;
 import com.odysee.app.data.DatabaseHelper;
@@ -127,14 +125,12 @@ public final class Helper {
         menu.add(QUALITIES_GROUP_ID, 0, ++order, R.string.auto_quality);
 
         if (isTranscoded) {
-            TracksInfo tracksInfo = player.getCurrentTracksInfo();
-            for (TrackGroupInfo groupInfo : tracksInfo.getTrackGroupInfos()) {
-                if (groupInfo.getTrackType() != C.TRACK_TYPE_VIDEO) continue;
-                TrackGroup group = groupInfo.getTrackGroup();
+            for (Tracks.Group trackGroup : player.getCurrentTracks().getGroups()) {
+                if (trackGroup.getType() != C.TRACK_TYPE_VIDEO) continue;
 
-                for (int i = 0; i < group.length; i++) {
-                    if (groupInfo.isTrackSupported(i)) {
-                        int quality = group.getFormat(i).height;
+                for (int i = 0; i < trackGroup.length; i++) {
+                    if (trackGroup.isTrackSupported(i)) {
+                        int quality = trackGroup.getTrackFormat(i).height;
                         menu.add(QUALITIES_GROUP_ID, quality, ++order, String.format("%sp", quality));
                     }
                 }


### PR DESCRIPTION
Required for fix in cast extension 2.17.0 to depend on up-to-date cast
library that creates PendingIntent correctly.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Other - Please describe: Dependency Bump

## Fixes

Issue Number: N/A

## What is the current behavior?

## What is the new behavior?

No change to user-facing behavior.
