### PR TITLE
Fix a crash when loading related content with a null claim item on the results

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -3618,7 +3618,7 @@ public class FileViewFragment extends BaseFragment implements
                             Callable<List<Claim>> resolveCallable = () -> Lbry.resolve(urls, Lbry.API_CONNECTION_STRING);
                             Future<List<Claim>> resolveFuture = ((OdyseeApp) a.getApplication()).getExecutor().submit(resolveCallable);
 
-                            List<Claim> result = resolveFuture.get();
+                            List<Claim> result = resolveFuture.get().stream().filter(c -> c != null).collect(Collectors.toList());
                             if (!urls.contains("")) {
                                 urls.add(""); // Explicit empty string as catch-all for LbryUri.normalize errors
                             }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #303

## What is the current behavior?
App crashes when some claim result item is null while loading related content
## What is the new behavior?
No more crashing there