### PR TITLE
Replace Ordering.explicit() with Comparator.comparing()

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -86,7 +86,6 @@ import com.google.android.flexbox.FlexboxLayoutManager;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.textfield.TextInputEditText;
 
-import com.google.common.collect.Ordering;
 import com.odysee.app.callable.ChannelLiveStatus;
 import com.odysee.app.OdyseeApp;
 import org.commonmark.Extension;
@@ -3188,7 +3187,8 @@ public class FileViewFragment extends BaseFragment implements
 
                     playlistResolved = true;
 
-                    Collections.sort(claims, Ordering.explicit(fileClaim.getClaimIds()).onResultOf(Claim::getClaimId));
+                    List<String> playlistClaimIds = fileClaim.getClaimIds();
+                    Collections.sort(claims, Comparator.comparing(claim -> playlistClaimIds.indexOf(claim.getClaimId())));
 
                     a.runOnUiThread(new Runnable() {
                         @Override
@@ -3538,13 +3538,13 @@ public class FileViewFragment extends BaseFragment implements
                             if (!urls.contains("")) {
                                 urls.add(""); // Explicit empty string as catch-all for LbryUri.normalize errors
                             }
-                            Collections.sort(result, Ordering.explicit(urls).onResultOf(claim -> {
+                            Collections.sort(result, Comparator.comparing(claim -> {
                                 try {
-                                    return LbryUri.normalize(claim.getPermanentUrl());
+                                    return urls.indexOf(LbryUri.normalize(claim.getPermanentUrl()));
                                 } catch (LbryUriException ex) {
                                     ex.printStackTrace();
+                                    return urls.indexOf("");
                                 }
-                                return "";
                             }));
 
                             a.runOnUiThread(new Runnable() {

--- a/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
@@ -21,7 +21,6 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
-import com.google.common.collect.Ordering;
 import com.odysee.app.OdyseeApp;
 import com.odysee.app.callable.LighthouseSearch;
 import org.json.JSONException;
@@ -29,7 +28,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
+import java.util.Comparator;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -536,13 +535,13 @@ public class SearchFragment extends BaseFragment implements
                         if (!urls.contains("")) {
                             urls.add(""); // Explicit empty string as catch-all for LbryUri.normalize errors
                         }
-                        Collections.sort(results, Ordering.explicit(urls).onResultOf(claim -> {
+                        Collections.sort(results, Comparator.comparing(claim -> {
                             try {
-                                return LbryUri.normalize(claim.getPermanentUrl());
+                                return urls.indexOf(LbryUri.normalize(claim.getPermanentUrl()));
                             } catch (LbryUriException ex) {
                                 ex.printStackTrace();
+                                return urls.indexOf("");
                             }
-                            return "";
                         }));
 
                         List<Claim> sanitizedClaims = results.stream().filter(item -> !item.getValueType().equalsIgnoreCase(Claim.TYPE_REPOST))


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## Fixes

Issue Number: #305 

## What is the current behavior?
Guava Ordering.explicit() is used which offers the same functionality that standard Comparator
## What is the new behavior?
Standard Comparator is being used
## Other information
From what I have seen, original code took a List as the sorting order for items, then sorts a List of claims so it matches the first List. This is now be done using Comparator.comparing() instead of using an external library.