### PR TITLE
Fix app bar titles not showing, format fragment_publish_form.xml

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -95,6 +95,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
@@ -1431,13 +1432,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         }
     }
 
-    public void setActionBarTitle(int stringResourceId) {
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            SpannableString spannable = new SpannableString(getString(stringResourceId));
-            spannable.setSpan(new TypefaceSpan("inter"), 0, spannable.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-            actionBar.setTitle(spannable);
-        }
+    public void setActionBarTitle(@StringRes int stringResourceId) {
+        ((TextView) findViewById(R.id.title)).setText(stringResourceId);
+        findViewById(R.id.title).setVisibility(View.VISIBLE);
     }
 
     public void addScreenOrientationListener(ScreenOrientationListener listener) {
@@ -1555,6 +1552,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         getSupportFragmentManager().popBackStack();
         findViewById(R.id.fragment_container_main_activity).setVisibility(View.VISIBLE);
         findViewById(R.id.bottom_navigation).setVisibility(View.VISIBLE);
+        findViewById(R.id.title).setVisibility(View.GONE);
         findViewById(R.id.toolbar_balance_and_tools_layout).setVisibility(View.VISIBLE);
     }
 
@@ -3679,6 +3677,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     findViewById(R.id.fragment_container_main_activity).setVisibility(View.VISIBLE);
                     showBottomNavigation();
                 }
+                findViewById(R.id.title).setVisibility(View.GONE);
                 findViewById(R.id.toolbar_balance_and_tools_layout).setVisibility(View.VISIBLE);
 
                 ActionBar actionBar = getSupportActionBar();
@@ -4439,6 +4438,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             currentDisplayFragment = fragment;
             findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);
             findViewById(R.id.bottom_navigation).setVisibility(View.GONE);
+            findViewById(R.id.title).setVisibility(View.GONE);
             findViewById(R.id.toolbar_balance_and_tools_layout).setVisibility(View.GONE);
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
@@ -25,12 +25,12 @@ import android.widget.AdapterView;
 import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatSpinner;
 import androidx.cardview.widget.CardView;
-import androidx.core.widget.NestedScrollView;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.arthenica.mobileffmpeg.Config;
@@ -140,7 +140,7 @@ public class PublishFormFragment extends BaseFragment implements
     private AppCompatSpinner languageSpinner;
     private AppCompatSpinner licenseSpinner;
 
-    private NestedScrollView scrollView;
+    private ScrollView scrollView;
     private View layoutExtraFields;
     private TextView linkShowExtraFields;
     private View textNoPrice;
@@ -344,7 +344,7 @@ public class PublishFormFragment extends BaseFragment implements
                     scrollView.post(new Runnable() {
                         @Override
                         public void run() {
-                            scrollView.fullScroll(NestedScrollView.FOCUS_DOWN);
+                            scrollView.fullScroll(ScrollView.FOCUS_DOWN);
                         }
                     });
                 } else {

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -26,7 +26,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-                <ImageView android:id="@+id/brand"
+                <ImageView
+                    android:id="@+id/brand"
                     android:layout_width="80dp"
                     android:layout_height="wrap_content"
                     android:adjustViewBounds="true"
@@ -36,7 +37,21 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <LinearLayout android:id="@+id/toolbar_balance_and_tools_layout"
+                <TextView
+                    android:id="@+id/title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    style="@style/TextView_Light"
+                    android:paddingStart="16dp"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/brand"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:ignore="RtlSymmetry" />
+
+                <LinearLayout
+                    android:id="@+id/toolbar_balance_and_tools_layout"
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:layout_alignParentEnd="true"

--- a/app/src/main/res/layout/fragment_publish_form.xml
+++ b/app/src/main/res/layout/fragment_publish_form.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/pageBackground">
-    <androidx.core.widget.NestedScrollView
+    <ScrollView
         android:id="@+id/publish_form_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -24,7 +24,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:padding="16dp">
-
+                <!-- region: Title, URL, Description -->
                 <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
@@ -72,6 +72,7 @@
                                     android:textSize="14sp" />
                             </com.google.android.material.textfield.TextInputLayout>
                         </LinearLayout>
+
                         <TextView
                             android:id="@+id/publish_form_inline_address_invalid"
                             android:layout_width="wrap_content"
@@ -98,7 +99,9 @@
                         </com.google.android.material.textfield.TextInputLayout>
                     </LinearLayout>
                 </androidx.cardview.widget.CardView>
+                <!-- endregion -->
 
+                <!-- region: Video Optimization -->
                 <androidx.cardview.widget.CardView
                     android:id="@+id/publish_form_video_opt_card"
                     android:layout_width="match_parent"
@@ -130,6 +133,7 @@
                                 style="@style/TextView_Light"
                                 android:textSize="16sp" />
                         </RelativeLayout>
+
                         <TextView
                             android:id="@+id/publish_form_video_opt_status"
                             android:layout_width="wrap_content"
@@ -171,7 +175,9 @@
                         </RelativeLayout>
                     </LinearLayout>
                 </androidx.cardview.widget.CardView>
+                <!-- endregion -->
 
+                <!-- region: Tags -->
                 <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -188,10 +194,13 @@
                             android:fontFamily="@font/inter"
                             android:textSize="20sp"
                             android:text="@string/tags" />
+
                         <include layout="@layout/container_inline_tag_form" />
                     </LinearLayout>
                 </androidx.cardview.widget.CardView>
+                <!-- endregion -->
 
+                <!-- region: Thumbnail -->
                 <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -215,7 +224,6 @@
                             android:layout_width="match_parent"
                             android:layout_height="240dp"
                             android:background="@android:color/black">
-
                             <ImageView
                                 android:id="@+id/publish_form_thumbnail_preview"
                                 android:layout_width="match_parent"
@@ -238,6 +246,7 @@
                                 <ProgressBar
                                     android:layout_width="16dp"
                                     android:layout_height="16dp" />
+
                                 <TextView
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
@@ -265,7 +274,9 @@
                         </RelativeLayout>
                     </LinearLayout>
                 </androidx.cardview.widget.CardView>
+                <!-- endregion -->
 
+                <!-- region: Channel -->
                 <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -279,7 +290,6 @@
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
                             android:layout_marginBottom="8dp">
-
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
@@ -287,6 +297,7 @@
                                 android:fontFamily="@font/inter"
                                 android:text="@string/channel"
                                 android:textSize="20sp" />
+
                             <ProgressBar
                                 android:id="@+id/publish_form_loading_channels"
                                 android:layout_width="20dp"
@@ -295,6 +306,7 @@
                                 android:layout_centerVertical="true"
                                 android:visibility="gone" />
                         </RelativeLayout>
+
                         <androidx.appcompat.widget.AppCompatSpinner
                             android:id="@+id/publish_form_channel_spinner"
                             android:layout_width="match_parent"
@@ -302,262 +314,286 @@
                             android:layout_marginTop="4dp" />
                     </LinearLayout>
                 </androidx.cardview.widget.CardView>
+                <!-- endregion -->
 
-                <LinearLayout
+                <!-- region: Additional Options -->
+                <androidx.cardview.widget.CardView
                     android:id="@+id/publish_form_extra_options_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
                     android:visibility="gone">
-                    <androidx.cardview.widget.CardView
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp">
+                        android:orientation="vertical"
+                        android:padding="16dp">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="8dp"
+                            android:fontFamily="@font/inter"
+                            android:textSize="20sp"
+                            android:text="@string/additional_options" />
+
+                        <!-- region: Additional Options - Release Time -->
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            style="@style/TextView_Light"
+                            android:fontFamily="@font/inter"
+                            android:textSize="14sp"
+                            android:text="@string/release_time" />
+
                         <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:padding="16dp">
+                            android:orientation="horizontal">
+                            <TextView
+                                android:id="@+id/publish_form_release_date"
+                                style="@style/TextView_Light"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:clickable="true"
+                                android:focusable="true"
+                                android:fontFamily="@font/inter"
+                                android:text="@string/time_default"
+                                android:textColor="@color/odyseePink"
+                                android:textSize="14sp" />
+
+                            <TextView
+                                android:id="@+id/publish_form_release_time"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="8sp"
+                                android:visibility="gone"
+                                android:clickable="true"
+                                android:focusable="true"
+                                style="@style/TextView_Light"
+                                android:fontFamily="@font/inter"
+                                android:textColor="@color/odyseePink"
+                                android:textSize="14sp"
+                                android:text="@string/time_default" />
+                        </LinearLayout>
+
+                        <TextView
+                            android:id="@+id/publish_form_release_time_future_not_allowed"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:visibility="gone"
+                            style="@style/TextView_Light"
+                            android:fontFamily="@font/inter"
+                            android:textSize="14sp"
+                            android:text="@string/future_not_allowed" />
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/publish_form_release_time_now"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:minWidth="0dp"
+                                android:minHeight="0dp"
+                                android:fontFamily="@font/inter"
+                                android:text="@string/time_now" />
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/publish_form_release_time_default"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:minWidth="0dp"
+                                android:minHeight="0dp"
+                                android:visibility="gone"
+                                android:fontFamily="@font/inter"
+                                android:text="@string/time_default" />
+                        </LinearLayout>
+                        <!-- endregion -->
+
+                        <!-- region: Additional Options - Language -->
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            style="@style/TextView_Light"
+                            android:text="@string/language"
+                            android:textSize="14sp" />
+
+                        <androidx.appcompat.widget.AppCompatSpinner
+                            android:id="@+id/publish_form_language_spinner"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp" />
+                        <!-- endregion -->
+
+                        <!-- region: Additional Options - License -->
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            style="@style/TextView_Light"
+                            android:text="@string/license"
+                            android:textSize="14sp" />
+
+                        <androidx.appcompat.widget.AppCompatSpinner
+                            android:id="@+id/publish_form_license_spinner"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp" />
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/publish_form_license_other_layout"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            android:hint="@string/license_desc"
+                            android:visibility="gone">
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/publish_form_input_license_other"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                style="@style/TextView_Light"
+                                android:inputType="textNoSuggestions"
+                                android:textSize="14sp" />
+                        </com.google.android.material.textfield.TextInputLayout>
+                        <!-- endregion -->
+
+                        <!-- region: Additional Options - Price -->
+                        <RelativeLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
+                                android:layout_centerVertical="true"
                                 android:layout_marginBottom="8dp"
                                 android:fontFamily="@font/inter"
-                                android:textSize="20sp"
-                                android:text="@string/additional_options" />
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                style="@style/TextView_Light"
-                                android:fontFamily="@font/inter"
-                                android:textSize="14sp"
-                                android:text="@string/release_time" />
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="horizontal">
-                                <TextView
-                                    android:id="@+id/publish_form_release_date"
-                                    style="@style/TextView_Light"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:clickable="true"
-                                    android:focusable="true"
-                                    android:fontFamily="@font/inter"
-                                    android:text="@string/time_default"
-                                    android:textColor="@color/odyseePink"
-                                    android:textSize="14sp" />
-                                <TextView
-                                    android:id="@+id/publish_form_release_time"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginStart="8sp"
-                                    android:visibility="gone"
-                                    android:clickable="true"
-                                    android:focusable="true"
-                                    style="@style/TextView_Light"
-                                    android:fontFamily="@font/inter"
-                                    android:textColor="@color/odyseePink"
-                                    android:textSize="14sp"
-                                    android:text="@string/time_default" />
-                            </LinearLayout>
-                            <TextView
-                                android:id="@+id/publish_form_release_time_future_not_allowed"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:visibility="gone"
-                                style="@style/TextView_Light"
-                                android:fontFamily="@font/inter"
-                                android:textSize="14sp"
-                                android:text="@string/future_not_allowed" />
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="horizontal">
-                                <com.google.android.material.button.MaterialButton
-                                    android:id="@+id/publish_form_release_time_now"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:minWidth="0dp"
-                                    android:minHeight="0dp"
-                                    android:fontFamily="@font/inter"
-                                    android:text="@string/time_now" />
-                                <com.google.android.material.button.MaterialButton
-                                    android:id="@+id/publish_form_release_time_default"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:minWidth="0dp"
-                                    android:minHeight="0dp"
-                                    android:visibility="gone"
-                                    android:fontFamily="@font/inter"
-                                    android:text="@string/time_default" />
-                            </LinearLayout>
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="8dp"
-                                style="@style/TextView_Light"
-                                android:text="@string/language"
+                                android:text="@string/price"
                                 android:textSize="14sp" />
-                            <androidx.appcompat.widget.AppCompatSpinner
-                                android:id="@+id/publish_form_language_spinner"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="4dp" />
 
-                            <TextView
+                            <com.google.android.material.switchmaterial.SwitchMaterial
+                                android:id="@+id/publish_form_price_switch"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginTop="8dp"
-                                style="@style/TextView_Light"
-                                android:text="@string/license"
-                                android:textSize="14sp" />
-                            <androidx.appcompat.widget.AppCompatSpinner
-                                android:id="@+id/publish_form_license_spinner"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="4dp" />
+                                android:layout_alignParentEnd="true"
+                                android:layout_centerVertical="true" />
+                        </RelativeLayout>
 
+                        <TextView
+                            android:id="@+id/publish_form_no_price"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/free_publish"
+                            style="@style/TextView_Light"
+                            android:textSize="14sp" />
+
+                        <RelativeLayout
+                            android:id="@+id/publish_form_price_container"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:visibility="gone">
                             <com.google.android.material.textfield.TextInputLayout
-                                android:id="@+id/publish_form_license_other_layout"
-                                android:layout_width="match_parent"
+                                android:id="@+id/publish_form_price_layout"
+                                android:layout_width="100dp"
                                 android:layout_height="wrap_content"
-                                android:layout_marginTop="16dp"
-                                android:hint="@string/license_desc"
-                                android:visibility="gone">
+                                android:hint="@string/price">
                                 <com.google.android.material.textfield.TextInputEditText
-                                    android:id="@+id/publish_form_input_license_other"
+                                    android:id="@+id/publish_form_input_price"
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     style="@style/TextView_Light"
-                                    android:inputType="textNoSuggestions"
+                                    android:textSize="14sp"
+                                    android:inputType="numberDecimal" />
+                            </com.google.android.material.textfield.TextInputLayout>
+
+                            <androidx.appcompat.widget.AppCompatSpinner
+                                android:id="@+id/publish_form_currency_spinner"
+                                android:entries="@array/publish_currencies"
+                                android:layout_width="160dp"
+                                android:layout_height="wrap_content"
+                                android:layout_toEndOf="@+id/publish_form_price_layout"
+                                android:layout_marginStart="4dp"
+                                android:layout_marginTop="24dp" />
+                        </RelativeLayout>
+                        <!-- endregion -->
+
+                        <!-- region: Additional Options - Deposit -->
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            style="@style/TextView_Light"
+                            android:text="@string/deposit"
+                            android:textSize="14sp" />
+
+                        <RelativeLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp">
+                            <com.google.android.material.textfield.TextInputLayout
+                                android:id="@+id/publish_form_input_layout_deposit"
+                                android:layout_width="100dp"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/deposit">
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/publish_form_input_deposit"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:fontFamily="@font/inter"
+                                    android:inputType="numberDecimal"
+                                    android:singleLine="true"
+                                    android:text="@string/min_deposit"
                                     android:textSize="14sp" />
                             </com.google.android.material.textfield.TextInputLayout>
 
-                            <RelativeLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content">
-                                <TextView
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:layout_centerVertical="true"
-                                    android:layout_marginBottom="8dp"
-                                    android:fontFamily="@font/inter"
-                                    android:text="@string/price"
-                                    android:textSize="14sp" />
-                                <com.google.android.material.switchmaterial.SwitchMaterial
-                                    android:id="@+id/publish_form_price_switch"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:layout_alignParentEnd="true"
-                                    android:layout_centerVertical="true" />
-                            </RelativeLayout>
                             <TextView
-                                android:id="@+id/publish_form_no_price"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/free_publish"
+                                android:id="@+id/publish_form_input_currency"
                                 style="@style/TextView_Light"
-                                android:textSize="14sp" />
-                            <RelativeLayout
-                                android:id="@+id/publish_form_price_container"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:visibility="gone">
-                                <com.google.android.material.textfield.TextInputLayout
-                                    android:id="@+id/publish_form_price_layout"
-                                    android:layout_width="100dp"
-                                    android:layout_height="wrap_content"
-                                    android:hint="@string/price">
-                                    <com.google.android.material.textfield.TextInputEditText
-                                        android:id="@+id/publish_form_input_price"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="wrap_content"
-                                        style="@style/TextView_Light"
-                                        android:textSize="14sp"
-                                        android:inputType="numberDecimal" />
-                                </com.google.android.material.textfield.TextInputLayout>
-                                <androidx.appcompat.widget.AppCompatSpinner
-                                    android:id="@+id/publish_form_currency_spinner"
-                                    android:entries="@array/publish_currencies"
-                                    android:layout_width="160dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_toEndOf="@+id/publish_form_price_layout"
-                                    android:layout_marginStart="4dp"
-                                    android:layout_marginTop="24dp" />
-                            </RelativeLayout>
+                                android:layout_marginStart="8dp"
+                                android:layout_marginTop="30dp"
+                                android:layout_toEndOf="@id/publish_form_input_layout_deposit"
+                                android:text="@string/lbc"
+                                android:textAllCaps="true"
+                                android:textSize="11sp" />
 
-                            <TextView
+                            <LinearLayout
+                                android:id="@+id/publish_form_inline_balance_container"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginTop="8dp"
-                                style="@style/TextView_Light"
-                                android:text="@string/deposit"
-                                android:textSize="14sp" />
-                            <RelativeLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="4dp">
-                                <com.google.android.material.textfield.TextInputLayout
-                                    android:id="@+id/publish_form_input_layout_deposit"
-                                    android:layout_width="100dp"
-                                    android:layout_height="wrap_content"
-                                    android:hint="@string/deposit">
-                                    <com.google.android.material.textfield.TextInputEditText
-                                        android:id="@+id/publish_form_input_deposit"
-                                        android:layout_width="match_parent"
-                                        android:layout_height="wrap_content"
-                                        android:fontFamily="@font/inter"
-                                        android:inputType="numberDecimal"
-                                        android:singleLine="true"
-                                        android:text="@string/min_deposit"
-                                        android:textSize="14sp" />
-                                </com.google.android.material.textfield.TextInputLayout>
+                                android:layout_marginStart="24dp"
+                                android:layout_marginTop="28dp"
+                                android:layout_toEndOf="@id/publish_form_input_currency"
+                                android:orientation="horizontal"
+                                android:visibility="invisible">
+                                <ImageView
+                                    android:layout_width="12dp"
+                                    android:layout_height="12dp"
+                                    android:layout_gravity="center_vertical"
+                                    android:src="@drawable/ic_credits" />
+
                                 <TextView
-                                    android:id="@+id/publish_form_input_currency"
+                                    android:id="@+id/publish_form_inline_balance_value"
                                     style="@style/TextView_Light"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:layout_marginStart="8dp"
-                                    android:layout_marginTop="30dp"
-                                    android:layout_toEndOf="@id/publish_form_input_layout_deposit"
-                                    android:text="@string/lbc"
-                                    android:textAllCaps="true"
-                                    android:textSize="11sp" />
-                                <LinearLayout
-                                    android:id="@+id/publish_form_inline_balance_container"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginStart="24dp"
-                                    android:layout_marginTop="28dp"
-                                    android:layout_toEndOf="@id/publish_form_input_currency"
-                                    android:orientation="horizontal"
-                                    android:visibility="invisible">
-                                    <ImageView
-                                        android:layout_width="12dp"
-                                        android:layout_height="12dp"
-                                        android:layout_gravity="center_vertical"
-                                        android:src="@drawable/ic_credits" />
-                                    <TextView
-                                        android:id="@+id/publish_form_inline_balance_value"
-                                        style="@style/TextView_Light"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:layout_marginStart="2dp" />
-                                </LinearLayout>
-                            </RelativeLayout>
+                                    android:layout_marginStart="2dp" />
+                            </LinearLayout>
+                        </RelativeLayout>
 
-                            <TextView
-                                style="@style/TextView_Light"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="4dp"
-                                android:text="@string/deposit_remains_yours"
-                                android:textSize="14sp" />
-                        </LinearLayout>
-                    </androidx.cardview.widget.CardView>
-                </LinearLayout>
+                        <TextView
+                            style="@style/TextView_Light"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp"
+                            android:text="@string/deposit_remains_yours"
+                            android:textSize="14sp" />
+                        <!-- endregion -->
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+                <!-- endregion -->
             </LinearLayout>
 
             <TextView
@@ -571,8 +607,9 @@
                 android:layout_marginEnd="16dp"
                 style="@style/TextView_Light"
                 android:text="@string/show_extra_fields"
-                android:focusable="true"/>
+                android:focusable="true" />
 
+            <!-- region: Cancel / Publish Buttons -->
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -583,13 +620,13 @@
                     android:id="@+id/publish_form_cancel"
                     android:background="?attr/selectableItemBackground"
                     android:clickable="true"
+                    android:focusable="true"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"
                     android:layout_marginTop="24dp"
                     style="@style/TextView_Light"
-                    android:text="@string/cancel" android:focusable="true"/>
-
+                    android:text="@string/cancel" />
 
                 <ProgressBar
                     android:id="@+id/publish_form_publishing"
@@ -599,6 +636,7 @@
                     android:layout_marginEnd="16dp"
                     android:layout_toStartOf="@id/publish_form_publish_button"
                     android:visibility="gone" />
+
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/publish_form_publish_button"
                     android:layout_width="wrap_content"
@@ -608,6 +646,7 @@
                     android:fontFamily="@font/inter"
                     android:text="@string/publish" />
             </RelativeLayout>
+            <!-- endregion -->
         </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- Add TextView to custom app bar to display title. Built in title view
  is placed below custom views so is not visible.
- Add regions to fragment_publish_form.xml to make sections of the form
  easier to separate.
- Replace NestedScrollView -> ScrollView as it is not needed (the only
  scrolling view, the tags view, is limited to 5 added + 8 suggested,
  which doesn't need to scroll).
- Remove redundant LinearLayout from around Additional Options card

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Code style update (formatting)
- [x] Refactoring (no functional changes)

## Fixes

Issue Number: N/A

## What is the current behavior?

Titles in app bar are set but not visible.

## What is the new behavior?

Titles in app bar (set using `setActionBarTitle`) are displayed in TextView in custom app bar.
