### PR TITLE
Make it possible to delete pending claims

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -497,16 +497,13 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         vh.itemView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (isPending) {
+                if (inSelectionMode) {
+                    toggleSelectedClaim(original);
+                } else if (isPending) {
                     Snackbar snackbar = Snackbar.make(vh.itemView, R.string.item_pending_blockchain, Snackbar.LENGTH_LONG);
                     TextView snackbarText = snackbar.getView().findViewById(com.google.android.material.R.id.snackbar_text);
                     snackbarText.setMaxLines(5);
                     snackbar.show();
-                    return;
-                }
-
-                if (inSelectionMode) {
-                    toggleSelectedClaim(original);
                 } else {
                     if (listener != null) {
                         listener.onClaimClicked(item, vh.getAbsoluteAdapterPosition());
@@ -518,14 +515,6 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
             @Override
             public boolean onLongClick(View view) {
                 if (!canEnterSelectionMode) {
-                    return false;
-                }
-
-                if (isPending) {
-                    Snackbar snackbar = Snackbar.make(vh.itemView, R.string.item_pending_blockchain, Snackbar.LENGTH_LONG);
-                    TextView snackbarText = snackbar.getView().findViewById(com.google.android.material.R.id.snackbar_text);
-                    snackbarText.setMaxLines(5);
-                    snackbar.show();
                     return false;
                 }
 

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelManagerFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelManagerFragment.java
@@ -269,7 +269,8 @@ public class ChannelManagerFragment extends BaseFragment implements ActionMode.C
     @Override
     public boolean onPrepareActionMode(androidx.appcompat.view.ActionMode actionMode, Menu menu) {
         int selectionCount = adapter != null ? adapter.getSelectedCount() : 0;
-        menu.findItem(R.id.action_edit).setVisible(selectionCount == 1);
+        menu.findItem(R.id.action_edit).setVisible(selectionCount == 1 &&
+                adapter.getSelectedItems().get(0).getConfirmations() > 0);
         return true;
     }
 

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishesFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishesFragment.java
@@ -221,6 +221,7 @@ public class PublishesFragment extends BaseFragment implements ActionMode.Callba
     public boolean onPrepareActionMode(androidx.appcompat.view.ActionMode actionMode, Menu menu) {
         int selectionCount = adapter != null ? adapter.getSelectedCount() : 0;
         menu.findItem(R.id.action_edit).setVisible(selectionCount == 1 &&
+                adapter.getSelectedItems().get(0).getConfirmations() > 0 &&
                 Claim.TYPE_STREAM.equalsIgnoreCase(adapter.getSelectedItems().get(0).getValueType()));
         return true;
     }


### PR DESCRIPTION
Hide edit action if pending claim selected. PublishForm doesn't seem to
handle getting the channel for a pending claim, so just disable edit.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: N/A

## What is the current behavior?

Pending claims show "claim is pending publish" toast and can't be selected to delete.

## What is the new behavior?

Pending claims are selectable and can be clicked to toggle selection, but clicking the claim still shows "claim is pending publish" message.

Claim editing is disabled on pending claims.
