### PR TITLE
Clear action bar title in Publishes and Channel Manager

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -1437,6 +1437,11 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         findViewById(R.id.title).setVisibility(View.VISIBLE);
     }
 
+    public void clearActionBarTitle() {
+        ((TextView) findViewById(R.id.title)).setText(null);
+        findViewById(R.id.title).setVisibility(View.GONE);
+    }
+
     public void addScreenOrientationListener(ScreenOrientationListener listener) {
         if (!screenOrientationListeners.contains(listener)) {
             screenOrientationListeners.add(listener);

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelManagerFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelManagerFragment.java
@@ -103,6 +103,7 @@ public class ChannelManagerFragment extends BaseFragment implements ActionMode.C
         Context context = getContext();
         if (context instanceof MainActivity) {
             MainActivity activity = (MainActivity) context;
+            activity.clearActionBarTitle();
             LbryAnalytics.setCurrentScreen(activity, "Channel Manager", "ChannelManager");
             MainActivity.suspendGlobalPlayer(context);
         }

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishesFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishesFragment.java
@@ -121,6 +121,7 @@ public class PublishesFragment extends BaseFragment implements ActionMode.Callba
         if (context instanceof MainActivity) {
             MainActivity activity = (MainActivity) context;
             activity.setWunderbarValue(null);
+            activity.clearActionBarTitle();
             LbryAnalytics.setCurrentScreen(activity, "Publishes", "Publishes");
         }
         if (adapter != null && contentList != null) {


### PR DESCRIPTION
Action bar title gets set by PublishForm and ChannelForm and stays set
when navigating back.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

- Go to "Publishes"
- Long press on a claim and click edit
- Press back
- Title "Edit content" still visible in Publishes page

## What is the new behavior?

No title is shown after pressing back
