### PR TITLE
Show LIVE as text on list item when no viewers are on livestream

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -671,9 +671,16 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                         liveText = context.getResources().getString(R.string.soon).toUpperCase();
                         vh.durationView.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, 0, 0);
                     } else {
-                        liveText = String.valueOf(item.getLivestreamViewers());
-                        vh.durationView.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, R.drawable.ic_viewerscount, 0);
-                        vh.durationView.setCompoundDrawablePadding(8);
+                        int livestreamViewers = item.getLivestreamViewers();
+
+                        if (livestreamViewers > 0) {
+                            liveText = String.valueOf(livestreamViewers);
+                            vh.durationView.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, R.drawable.ic_viewerscount, 0);
+                            vh.durationView.setCompoundDrawablePadding(8);
+                        } else {
+                            liveText = context.getResources().getString(R.string.live).toUpperCase();
+                            vh.durationView.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, 0, 0);
+                        }
                     }
 
                     vh.durationView.setText(liveText);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
When an active livestream has no viewers, a "0" is shown on the list of items
## What is the new behavior?
Now LIVE will be shown, as is the case on Odysee web UI