### PR TITLE
Show currently active livestreams for each category on the Home tab

### DIFF
--- a/app/src/main/java/com/odysee/app/callable/ChannelLiveStatus.java
+++ b/app/src/main/java/com/odysee/app/callable/ChannelLiveStatus.java
@@ -86,7 +86,8 @@ public class ChannelLiveStatus implements Callable<Map<String, JSONObject>> {
                 for (int i = 0; i < s; i++) {
                     JSONObject channelData = jsonData.getJSONObject(i);
 
-                    if (channelData.has("ChannelClaimID") && channelIds.contains(channelData.getString("ChannelClaimID"))) {
+                    if (channelData.has("ChannelClaimID") && channelIds.contains(channelData.getString("ChannelClaimID"))
+                            && (alwaysReturnData || (channelData.has("Live") && channelData.getBoolean("Live")))) {
                         streamingChannels.put(channelData.getString("ChannelClaimID"), channelData);
                     }
                 }

--- a/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -19,6 +21,9 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
 
+import com.odysee.app.OdyseeApp;
+import com.odysee.app.callable.ChannelLiveStatus;
+import com.odysee.app.callable.Search;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -27,6 +32,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import com.odysee.app.MainActivity;
 import com.odysee.app.R;
@@ -71,6 +80,11 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
     private TextView contentFromLinkText;
     private TextView scopeLinkText;
     private RecyclerView contentList;
+    private RecyclerView livestreamsList;
+    private ClaimListAdapter activeClaimsListAdapter;
+    private View activeLivestreamsLayout;
+    private boolean fetchingLivestreamingClaims = false;
+    private boolean livestreamingClaimsFetched = false;
     private int currentSortBy;
     private int currentContentFrom;
     @Getter
@@ -138,6 +152,8 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
                              ViewGroup container, Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.fragment_all_content, container, false);
 
+        Context context = getContext();
+
         // All content page is sorted by trending by default, past week if sort is top
         currentSortBy = ContentSortDialogFragment.ITEM_SORT_BY_TRENDING;
         currentContentFrom = ContentFromDialogFragment.ITEM_FROM_PAST_WEEK;
@@ -169,8 +185,22 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
             }
         });
 
+        activeLivestreamsLayout = root.findViewById(R.id.active_livestreams_container);
+        livestreamsList = root.findViewById(R.id.active_livestreams_recyclerview);
+
+        LinearLayoutManager hllm = new LinearLayoutManager(context, RecyclerView.HORIZONTAL, false);
+        livestreamsList.setLayoutManager(hllm);
+        root.findViewById(R.id.expand_active_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Helper.setViewVisibility(livestreamsList, livestreamsList.getVisibility() == View.VISIBLE ? View.GONE: View.VISIBLE);
+                // This is different from the expansion button for scheduled livestreams as this is only used on the Home tab.
+                // That's the reason why there is no persistence code needed. Last state will remain for all categories on the session.
+            }
+        });
+
         contentList = root.findViewById(R.id.all_content_list);
-        LinearLayoutManager llm = new LinearLayoutManager(getContext());
+        LinearLayoutManager llm = new LinearLayoutManager(context);
         contentList.setLayoutManager(llm);
         contentList.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
@@ -273,6 +303,8 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
         }
 
         if (reload) {
+            livestreamingClaimsFetched = false;
+            fetchActiveLivestreams();
             fetchClaimSearchContent(true);
         }
     }
@@ -288,6 +320,8 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
 
     private void onCategoryChanged() {
         Helper.setViewVisibility(layoutFilterContainer, currentCategoryId == wildWestIndex ? View.GONE : View.VISIBLE);
+        livestreamingClaimsFetched = false;
+        fetchActiveLivestreams();
         fetchClaimSearchContent(true);
     }
 
@@ -547,6 +581,165 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
     private void checkNoContent() {
         boolean noContent = contentListAdapter == null || contentListAdapter.getItemCount() == 0;
         Helper.setViewVisibility(noContentView, noContent ? View.VISIBLE : View.GONE);
+    }
+
+    private void fetchActiveLivestreams() {
+        if (!fetchingLivestreamingClaims && !livestreamingClaimsFetched) {
+            fetchingLivestreamingClaims = true;
+            if (activeClaimsListAdapter != null) {
+                activeClaimsListAdapter.clearItems();
+            }
+
+            Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    List<Claim> activeClaims = findActiveLivestreams();
+                    fetchingLivestreamingClaims = false;
+
+                    if (activeClaims != null && activeClaims.size() > 0) {
+                        activeClaims = Helper.filterClaimsByOutpoint(activeClaims);
+
+                        List<Claim> finalActiveClaims = activeClaims;
+                        new Handler(Looper.getMainLooper()).post(new Runnable() {
+                            @Override
+                            public void run() {
+                                if (activeClaimsListAdapter == null) {
+                                    Context context = getContext();
+                                    if (context != null) {
+                                        activeClaimsListAdapter = new ClaimListAdapter(finalActiveClaims, ClaimListAdapter.STYLE_SMALL_LIST_HORIZONTAL, context);
+                                        activeClaimsListAdapter.setListener(new ClaimListAdapter.ClaimListItemListener() {
+                                            @Override
+                                            public void onClaimClicked(Claim claim, int position) {
+                                                Context context = getContext();
+                                                if (context instanceof MainActivity) {
+                                                    MainActivity activity = (MainActivity) context;
+
+                                                    if (claim.getValueType().equals(Claim.TYPE_STREAM)) {
+                                                        activity.openFileClaim(claim);
+                                                    } else if (claim.getValueType().equals(Claim.TYPE_CHANNEL)) {
+                                                        activity.openChannelClaim(claim);
+                                                    }
+                                                }
+                                            }
+                                        });
+                                    }
+                                } else {
+                                    activeClaimsListAdapter.addItems(finalActiveClaims);
+                                }
+
+                                livestreamingClaimsFetched = true;
+
+                                if (livestreamsList != null && livestreamsList.getAdapter() == null) {
+                                    livestreamsList.setAdapter(activeClaimsListAdapter);
+                                }
+                            }
+                        });
+                    }
+
+                    new Handler(Looper.getMainLooper()).post(new Runnable() {
+                        @Override
+                        public void run() {
+                            checkNoActiveLivestreams();
+                        }
+                    });
+                }
+            });
+            t.start();
+        }
+    }
+
+    private List<Claim> findActiveLivestreams() {
+        MainActivity a = (MainActivity) getActivity();
+        List<Claim> subscribedUpcomingClaims = new ArrayList<>();
+        if (a != null) {
+            try {
+                List<String> channelIds = Arrays.asList(currentChannelIdList);
+
+                Callable<Map<String, JSONObject>> callable = new ChannelLiveStatus(channelIds, false, true);
+                Future<Map<String, JSONObject>> futureUpcoming = ((OdyseeApp) a.getApplication()).getExecutor().submit(callable);
+                Map<String, JSONObject> upcomingJsonData = futureUpcoming.get();
+
+                if (upcomingJsonData != null && upcomingJsonData.size() > 0) {
+                    List<String> claimIds = new ArrayList<>();
+
+                    upcomingJsonData.forEach((k, v) -> {
+                        try {
+                            if (v.getBoolean("Live") && v.has("ActiveClaim")) {
+                                String cid = v.getJSONObject("ActiveClaim").getString("ClaimID");
+                                claimIds.add(cid);
+                            }
+                        } catch (JSONException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    Map<String, Object> claimSearchOptions = buildActiveLivestreamsOptions();
+
+                    claimSearchOptions.put("claim_type", Collections.singletonList(Claim.TYPE_STREAM));
+                    claimSearchOptions.put("has_no_source", true);
+                    claimSearchOptions.put("claim_ids", claimIds);
+                    claimSearchOptions.put("page", 1);
+                    Future<List<Claim>> upcomingFuture = ((OdyseeApp) a.getApplication()).getExecutor().submit(new Search(claimSearchOptions));
+
+                    // Using two different variables to make it easier to debug
+                    List<Claim> upcomingClaims = upcomingFuture.get();
+
+                    subscribedUpcomingClaims = upcomingClaims.stream().filter(c -> {
+                        String channelId = c.getSigningChannel().getClaimId();
+                        return upcomingJsonData.containsKey(channelId);
+                    }).collect(Collectors.toList());
+
+                    for (Claim claim : subscribedUpcomingClaims) {
+                        try {
+                            String channelId = claim.getSigningChannel().getClaimId();
+                            JSONObject j = upcomingJsonData.get(channelId);
+                            if (j != null) {
+                                claim.setLivestreamUrl(j.getString("VideoURL"));
+                                claim.setLivestreamViewers(j.getInt("ViewerCount"));
+                                claim.setLive(true);
+                                claim.setHighlightLive(true);
+                            }
+                        } catch (JSONException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause != null) {
+                    cause.printStackTrace();
+                }
+                return null;
+            }
+        }
+        return subscribedUpcomingClaims;
+    }
+
+    private void checkNoActiveLivestreams() {
+        boolean noActive = activeClaimsListAdapter == null || activeClaimsListAdapter.getItemCount() == 0;
+        Helper.setViewVisibility(activeLivestreamsLayout, noActive ? View.GONE : View.VISIBLE);
+    }
+
+    private Map<String, Object> buildActiveLivestreamsOptions() {
+        Context context = getContext();
+        boolean canShowMatureContent = false;
+        if (context != null) {
+            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+            canShowMatureContent = sp.getBoolean(MainActivity.PREFERENCE_KEY_SHOW_MATURE_CONTENT, false);
+        }
+
+        return Lbry.buildClaimSearchOptions(
+                Collections.singletonList(Claim.TYPE_STREAM),
+                null,
+                canShowMatureContent ? null : new ArrayList<>(Predefined.MATURE_TAGS),
+                null,
+                Arrays.asList(currentChannelIdList),
+                Arrays.asList(dynamicCategories.get(currentCategoryId).getExcludedChannelIds()),
+                null,
+                null,
+                0,
+                0,
+                1,
+                Helper.CONTENT_PAGE_SIZE);
     }
 
     public void onSharedPreferenceChanged(SharedPreferences sp, String key) {

--- a/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
@@ -441,11 +441,9 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
         }
 
         List<String> channelIdsForCategory = null;
-        List<String> excludedChannelIdsForCategory = null;
+        List<String> excludedChannelIdsForCategory = Arrays.asList(dynamicCategories.get(currentCategoryId).getExcludedChannelIds());
 
-        if (currentCategoryId == wildWestIndex) {
-            excludedChannelIdsForCategory = Arrays.asList(dynamicCategories.get(currentCategoryId).getExcludedChannelIds());
-        } else if (currentChannelIdList != null) {
+        if (currentChannelIdList != null) {
             channelIdsForCategory = Arrays.asList(currentChannelIdList);
         } else {
             channelIdsForCategory = Arrays.asList(dynamicCategories.get(0).getChannelIds());

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -868,7 +868,6 @@ public class FollowingFragment extends BaseFragment implements
                             String livestreamUrl = j.getString("VideoURL");
                             int viewersCount = j.getInt("ViewerCount");
                             String startTime = j.getString("Start");
-                            System.out.println(pair.getKey() + " = " + pair.getValue());
                             if (!activeClaimId.equalsIgnoreCase("Confirming")) {
                                 activeClaims.add(Claim.fromLiveStatus(activeClaimId, livestreamUrl, viewersCount, startTime));
                                 activeClaimIds.add(activeClaimId);

--- a/app/src/main/res/layout/fragment_all_content.xml
+++ b/app/src/main/res/layout/fragment_all_content.xml
@@ -37,6 +37,55 @@
                 app:selectionRequired="true" />
         </HorizontalScrollView>
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/active_livestreams_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginStart="16dp"
+            android:orientation="vertical"
+            tools:visibility="visible"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/active_livestreams_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                android:gravity="center_vertical"
+                android:text="@string/livestreaming_now"
+                style="@style/TextView_SemiBold" />
+
+            <ImageButton android:id="@+id/expand_active_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:minWidth="48dp"
+                android:contentDescription="@string/active_expand_button_accessibility"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/active_livestreams_text"
+                app:layout_constraintBottom_toBottomOf="@id/active_livestreams_text"
+                app:tint="@color/colorPrimary"
+                android:background="?attr/selectableItemBackground"
+                android:src="@drawable/ic_expand"/>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/active_livestreams_recyclerview"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                app:layout_constraintTop_toBottomOf="@id/active_livestreams_text"
+                app:layout_constraintStart_toStartOf="parent"
+                android:scrollbars="horizontal"
+                tools:listitem="@layout/list_item_gallery"
+                tools:itemCount="2"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <RelativeLayout
             android:id="@+id/all_content_filter_container"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="theuniverse_category">The Universe</string>
     <string name="movies_category">Movies</string>
     <string name="wildwest_category">Rabbit Hole</string>
+    <string name="livestreaming_now">Livestreaming now</string>
+    <string name="active_expand_button_accessibility">Button to expand or contract active livestreams</string>
 
     <!-- Following page -->
     <string name="find_channels_to_follow">Find Channels to follow</string>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #313

## What is the current behavior?
No livestreams are listed for channels currently on a certain category
## What is the new behavior?
They are now shown