### PR TITLE
Filter scheduled livestreams according to channel selection on Following tab

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FollowingFragment.java
@@ -521,7 +521,7 @@ public class FollowingFragment extends BaseFragment implements
         if (channelFilterListAdapter != null) {
             Claim selected = channelFilterListAdapter.getSelectedItem();
             if (selected != null && !Helper.isNullOrEmpty(selected.getClaimId())) {
-                return Arrays.asList(selected.getClaimId());
+                return Collections.singletonList(selected.getClaimId());
             }
         }
 
@@ -626,6 +626,9 @@ public class FollowingFragment extends BaseFragment implements
                     currentClaimSearchPage = 1;
                     contentClaimSearchLoading = false;
                     fetchClaimSearchContent();
+                    fetchingScheduledClaims = false;
+                    scheduledClaimsFetched = false;
+                    fetchScheduledSubscribedContent();
                 }
 
                 @Override
@@ -644,6 +647,9 @@ public class FollowingFragment extends BaseFragment implements
                     currentClaimSearchPage = 1;
                     contentClaimSearchLoading = false;
                     fetchClaimSearchContent();
+                    fetchingScheduledClaims = false;
+                    scheduledClaimsFetched = false;
+                    fetchScheduledSubscribedContent();
                 }
             });
         }
@@ -663,6 +669,11 @@ public class FollowingFragment extends BaseFragment implements
     private void fetchScheduledSubscribedContent() {
         if (!fetchingScheduledClaims && !scheduledClaimsFetched) {
             fetchingScheduledClaims = true;
+
+            if (scheduledClaimsListAdapter != null) {
+                scheduledClaimsListAdapter.clearItems();
+                checkNoScheduledLivestreams();
+            }
 
             Thread t = new Thread(new Runnable() {
                 @Override
@@ -922,7 +933,7 @@ public class FollowingFragment extends BaseFragment implements
         List<Claim> subscribedUpcomingClaims = new ArrayList<>();
         if (a != null) {
             try {
-                Callable<Map<String, JSONObject>> callable = new ChannelLiveStatus(channelIds, true, true);
+                Callable<Map<String, JSONObject>> callable = new ChannelLiveStatus(getChannelIds(), true, true);
                 Future<Map<String, JSONObject>> futureUpcoming = ((OdyseeApp) a.getApplication()).getExecutor().submit(callable);
                 Map<String, JSONObject> upcomingJsonData = futureUpcoming.get();
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #337

## What is the current behavior?
After selecting a channel on the filter, scheduled livestream's list still shows claims for all channels
## What is the new behavior?
Now they are also filtered