### PR TITLE
Support dark theme for Markdown posts

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -3491,6 +3491,7 @@ public class FileViewFragment extends BaseFragment implements
                 "            <meta charset=\"utf-8\"/>\n" +
                 "            <meta name=\"viewport\" content=\"width=device-width, user-scalable=no\"/>\n" +
                 "            <style type=\"text/css\">\n" +
+                "              :root { color-scheme: light dark }\n" +
                 "              body { font-family: 'Inter', sans-serif; margin: 16px }\n" +
                 "              img { width: 100%; }\n" +
                 "              pre { white-space: pre-wrap; word-wrap: break-word }\n" +


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Even in dark mode Markdown posts are rendered in light theme

## What is the new behavior?

In dark mode Markdown posts are rendered in dark theme
