### PR TITLE
publish: fix using currency "lbry credits" when setting fee

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
@@ -1161,7 +1161,7 @@ public class PublishFormFragment extends BaseFragment implements
         }
         if (switchPrice.isChecked()) {
             Fee fee = new Fee();
-            fee.setCurrency((String) priceCurrencySpinner.getSelectedItem());
+            fee.setCurrency(priceCurrencySpinner.getSelectedItemPosition() == 0 ? "lbc" : "usd");
             fee.setAmount(Helper.getValue(inputPrice.getText()));
             metadata.setFee(fee);
         }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

When setting Fee in LBRY Credits, error "Missing or unknown currency provided: lbry credits" is shown.

## What is the new behavior?

Use "lbc" or "usd" based on currency seletion.
