### PR TITLE
Sync default channel name selection

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -1122,6 +1122,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         AccountManager am = AccountManager.get(ctx);
                         am.setUserData(Helper.getOdyseeAccount(am.getAccounts()), "default_channel_name", defaultChannelName);
                         ((ProfileDefaultChannelAdapter)defaultChannelList.getAdapter()).setDefaultChannelName(defaultChannelName);
+                        saveSharedUserState();
                     }
                 });
 

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -1012,6 +1012,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 buttonSignOut.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
 
                 if (isSignedIn) {
+                    loadSharedUserState();
                     userIdText.setVisibility(View.VISIBLE);
                     signUserButton.setVisibility(View.GONE);
                     userIdText.setText(am.getUserData(odyseeAccount, "email"));

--- a/app/src/main/java/com/odysee/app/tasks/wallet/SaveSharedUserStateTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/wallet/SaveSharedUserStateTask.java
@@ -1,10 +1,12 @@
 package com.odysee.app.tasks.wallet;
 
+import android.accounts.AccountManager;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.os.AsyncTask;
 
+import com.odysee.app.model.Claim;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,6 +16,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.odysee.app.MainActivity;
 import com.odysee.app.data.DatabaseHelper;
@@ -183,7 +186,19 @@ public class SaveSharedUserStateTask extends AsyncTask<Void, Void, Boolean> {
                         }
                     }
 
+                    JSONObject settings = Helper.getJSONObject("settings", value);
+                    if (settings != null) {
+                        AccountManager am = AccountManager.get(context);
+                        String channelName = am.getUserData(Helper.getOdyseeAccount(am.getAccounts()), "default_channel_name");
+                        List<Claim> filteredClaim = Lbry.ownChannels.stream().filter(c -> c.getName().equalsIgnoreCase(channelName)).collect(Collectors.toList());
+                        if (filteredClaim.size() == 1) {
+                            settings.put("active_channel_claim", filteredClaim.get(0).getClaimId());
+                        }
+                    }
+                    value.put("settings", settings);
+
                     sharedObject = shared;
+                    sharedObject.put("value", value);
                 }
             }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?
The channel which user wants to use for interactions is only locally stored
## What is the new behavior?
The channel selection is synchronized with the one user has set on the web interface and the web interface setting will be updated when selection changes on Odysee Android