### PR TITLE
Match Livestreaming UX flow to odysee.com

### DIFF
--- a/app/src/main/java/com/odysee/app/GoLiveActivity.java
+++ b/app/src/main/java/com/odysee/app/GoLiveActivity.java
@@ -1,8 +1,22 @@
 package com.odysee.app;
 
+import android.Manifest;
+import android.app.AlertDialog;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
-import android.util.Log;
+import android.graphics.Color;
+import android.hardware.camera2.CameraCharacteristics;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
 import android.view.WindowInsetsController;
+import android.view.WindowManager;
+
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -11,36 +25,8 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
-import android.Manifest;
-import android.accounts.AccountManager;
-import android.app.Activity;
-import android.app.AlertDialog;
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.content.pm.PackageManager;
-import android.graphics.Color;
-import android.hardware.camera2.CameraCharacteristics;
-import android.net.Uri;
-import android.os.AsyncTask;
-import android.os.Build;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
-import android.view.View;
-import android.view.WindowManager;
-import android.widget.AdapterView;
-import android.widget.ImageButton;
-import android.widget.ImageView;
-import android.widget.Spinner;
-import android.widget.TextView;
-
-import com.bumptech.glide.Glide;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.snackbar.Snackbar;
-import com.google.android.material.textfield.TextInputEditText;
 import com.haishinkit.event.Event;
 import com.haishinkit.event.IEventListener;
 import com.haishinkit.media.AudioRecordSource;
@@ -48,74 +34,35 @@ import com.haishinkit.media.Camera2Source;
 import com.haishinkit.rtmp.RtmpConnection;
 import com.haishinkit.rtmp.RtmpStream;
 import com.haishinkit.view.HkSurfaceView;
-import com.odysee.app.adapter.InlineChannelSpinnerAdapter;
-import com.odysee.app.exceptions.ApiCallException;
-import com.odysee.app.model.Claim;
-import com.odysee.app.supplier.ClaimListSupplier;
-import com.odysee.app.tasks.UploadImageTask;
-import com.odysee.app.tasks.claim.ClaimListResultHandler;
-import com.odysee.app.tasks.claim.ClaimListTask;
-import com.odysee.app.tasks.claim.ClaimResultHandler;
-import com.odysee.app.tasks.claim.PublishClaimTask;
 import com.odysee.app.utils.Helper;
-import com.odysee.app.utils.Lbry;
 import com.odysee.app.utils.LbryAnalytics;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 public class GoLiveActivity extends AppCompatActivity {
     private final String RTMP_URL = "rtmp://stream.odysee.com/live";
-    private final double MIN_STREAM_STAKE = 50;
 
-    private ImageView imagePrecheckSpaceman;
-    private TextView textPrecheckStatus;
-    private Spinner selectChannelSpinner;
-    private TextView textChannelError;
-    private TextInputEditText inputTitle;
-    private View progress;
-    private ImageView imageThumbnail;
-    private View thumbnailUploadProgress;
     private MaterialButton buttonToggleStreaming;
 
-    private View livestreamPrecheckView;
-    private View livestreamOptionsView;
-    private View livestreamControlsView;
-
-    private Claim selectedChannel;
     private String streamKey;
+    private boolean isStreaming;
+    private boolean startingStream;
+    private boolean screenTurnedOn;
+
     private RtmpConnection connection;
     private RtmpStream stream;
     private Camera2Source cameraSource;
     private BroadcastReceiver screenOnReceiver;
 
-    private boolean uploadingThumbnail;
-    private String uploadedThumbnailUrl;
-    private String lastSelectedThumbnailFile;
-    private boolean isStreaming;
-    private boolean startingStream;
-    private boolean screenTurnedOn;
-
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         // Change status bar text color depending on Night mode when app is running
         String darkModeAppSetting = ((OdyseeApp) getApplication()).getDarkModeAppSetting();
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1 && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             if (!darkModeAppSetting.equals(MainActivity.APP_SETTING_DARK_MODE_NIGHT) && AppCompatDelegate.getDefaultNightMode() != AppCompatDelegate.MODE_NIGHT_YES) {
-                //noinspection deprecation
                 getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
             }
         } else if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
@@ -124,7 +71,6 @@ public class GoLiveActivity extends AppCompatActivity {
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
                     getWindow().getDecorView().getWindowInsetsController().setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
                 } else {
-                    //noinspection deprecation
                     getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
                 }
             } else {
@@ -134,7 +80,27 @@ public class GoLiveActivity extends AppCompatActivity {
             }
         }
 
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        IntentFilter filter = new IntentFilter(Intent.ACTION_SCREEN_ON);
+        screenOnReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                screenTurnedOn = true;
+            }
+        };
+        registerReceiver(screenOnReceiver, filter);
+
         setContentView(R.layout.activity_go_live);
+
+        // If stream key not provided, fail
+        Intent intent = getIntent();
+        String extra = intent.getStringExtra("streamKey");
+        if (Helper.isNullOrEmpty(extra)) {
+            MainActivity.instance.showError(getString(R.string.no_stream_key_provided));
+            finish();
+            return;
+        }
+        streamKey = extra;
 
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {})
@@ -177,92 +143,21 @@ public class GoLiveActivity extends AppCompatActivity {
             }
         });
 
-        imagePrecheckSpaceman = findViewById(R.id.livestream_precheck_spaceman_image);
-        textPrecheckStatus = findViewById(R.id.livestream_precheck_status_text);
-        selectChannelSpinner = findViewById(R.id.livestream_options_select_channel_spinner);
-        textChannelError = findViewById(R.id.livestream_options_channel_error_text);
-        inputTitle = findViewById(R.id.livestream_options_title_input);
-        progress = findViewById(R.id.livestream_progress);
-        imageThumbnail = findViewById(R.id.livestream_options_thumbnail_preview);
-        thumbnailUploadProgress = findViewById(R.id.livestream_options_thumbnail_upload_progress);
+        ((HkSurfaceView) findViewById(R.id.livestream_controls_camera_view)).attachStream(stream);
 
-        livestreamPrecheckView = findViewById(R.id.livestream_precheck);
-        livestreamOptionsView = findViewById(R.id.livestream_options);
-        livestreamControlsView = findViewById(R.id.livestream_controls);
-
-        HkSurfaceView livestreamControlsCameraView = findViewById(R.id.livestream_controls_camera_view);
-        livestreamControlsCameraView.attachStream(stream);
-
-        MaterialButton buttonContinue = findViewById(R.id.livestream_options_continue_button);
         buttonToggleStreaming = findViewById(R.id.livestream_controls_toggle_streaming_button);
-        ImageButton buttonSwitchCamera = findViewById(R.id.livestream_controls_switch_camera_button);
-
-        selectChannelSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                selectedChannel = (Claim) selectChannelSpinner.getSelectedItem();
-                checkCanStreamOnChannel(selectedChannel);
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-
-            }
-        });
-
-        imageThumbnail.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                checkStoragePermissionAndLaunchFilePicker();
-            }
-        });
-
-        buttonContinue.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                if (uploadingThumbnail) {
-                    showError(getString(R.string.publish_thumbnail_in_progress));
-                    return;
-                }
-                if (!checkCanStreamOnChannel(selectedChannel)) {
-                    showError(getString(R.string.need_valid_channel));
-                    return;
-                }
-                if (Helper.isNullOrEmpty(Helper.getValue(inputTitle.getText()))) {
-                    showError(getString(R.string.specify_title));
-                    return;
-                }
-
-                progress.setVisibility(View.VISIBLE);
-                livestreamOptionsView.setVisibility(View.GONE);
-                textPrecheckStatus.setText(R.string.precheck_wait_confirmation);
-                livestreamPrecheckView.setVisibility(View.VISIBLE);
-                publishLivestreamClaim();
-            }
-        });
 
         buttonToggleStreaming.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(View v) {
                 if (startingStream) {
                     return;
                 }
                 if (!isStreaming) {
-                    getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-
-                    IntentFilter filter = new IntentFilter(Intent.ACTION_SCREEN_ON);
-                    screenOnReceiver = new BroadcastReceiver() {
-                        @Override
-                        public void onReceive(Context context, Intent intent) {
-                            screenTurnedOn = true;
-                        }
-                    };
-                    registerReceiver(screenOnReceiver, filter);
                     startingStream = true;
                     connection.connect(RTMP_URL);
                     buttonToggleStreaming.setText(R.string.stop_streaming);
                 } else {
-                    getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
                     connection.close();
                     isStreaming = false;
                     startingStream = false;
@@ -271,9 +166,9 @@ public class GoLiveActivity extends AppCompatActivity {
             }
         });
 
-        buttonSwitchCamera.setOnClickListener(new View.OnClickListener() {
+        findViewById(R.id.livestream_controls_switch_camera_button).setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(View v) {
                 cameraSource.switchCamera();
             }
         });
@@ -296,14 +191,15 @@ public class GoLiveActivity extends AppCompatActivity {
 
         LbryAnalytics.setCurrentScreen(this, "Go Live", "GoLive");
         checkCameraPermissionAndOpenCameraSource();
-
-        fetchChannels();
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        connection.dispose();
+        if (connection != null) {
+            connection.dispose();
+        }
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         if (screenOnReceiver != null) {
             unregisterReceiver(screenOnReceiver);
         }
@@ -311,42 +207,16 @@ public class GoLiveActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        if (isStreaming) {
-            new AlertDialog.Builder(this)
-                    .setTitle(R.string.stop_streaming)
-                    .setMessage(R.string.confirm_stop_message)
-                    .setNegativeButton(R.string.no, null)
-                    .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            GoLiveActivity.super.onBackPressed();
-                        }
-                    }).show();
-        } else {
-            super.onBackPressed();
-        }
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == MainActivity.REQUEST_FILE_PICKER
-                && resultCode == Activity.RESULT_OK && data != null) {
-            Uri fileUri = data.getData();
-            String filePath = Helper.getRealPathFromURI_API19(this, fileUri);
-
-            if (Helper.isNullOrEmpty(filePath)) {
-                showError(getString(R.string.undetermined_image_filepath));
-                return;
-            }
-
-            if (filePath.equalsIgnoreCase(lastSelectedThumbnailFile)) {
-                // previous selected thumbnail was uploaded successfully
-                return;
-            }
-
-            uploadThumbnail(filePath);
-        }
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.stop_streaming)
+                .setMessage(R.string.confirm_stop_message)
+                .setNegativeButton(R.string.no, null)
+                .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        GoLiveActivity.super.onBackPressed();
+                    }
+                }).show();
     }
 
     @Override
@@ -358,62 +228,7 @@ public class GoLiveActivity extends AppCompatActivity {
             } else {
                 showError(getString(R.string.camera_permission_rationale_livestream));
             }
-        } else if (requestCode == MainActivity.REQUEST_STORAGE_PERMISSION) {
-            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                launchFilePicker();
-            } else {
-                showError(getString(R.string.storage_permission_rationale_images));
-            }
         }
-    }
-
-    private void uploadThumbnail(String thumbnailPath) {
-        if (uploadingThumbnail) {
-            Snackbar.make(findViewById(R.id.livestream_main), R.string.wait_for_upload, Snackbar.LENGTH_LONG).show();
-            return;
-        }
-
-        Glide.with(thumbnailUploadProgress).load(thumbnailPath).centerCrop().into(imageThumbnail);
-
-        uploadingThumbnail = true;
-        uploadedThumbnailUrl = null;
-        UploadImageTask task = new UploadImageTask(thumbnailPath, thumbnailUploadProgress, new UploadImageTask.UploadThumbnailHandler() {
-            @Override
-            public void onSuccess(String url) {
-                lastSelectedThumbnailFile = thumbnailPath;
-                uploadedThumbnailUrl = url;
-                uploadingThumbnail = false;
-            }
-
-            @Override
-            public void onError(Exception error) {
-                showError(getString(R.string.image_upload_failed));
-                lastSelectedThumbnailFile = null;
-                imageThumbnail.setImageDrawable(null);
-                uploadingThumbnail = false;
-            }
-        });
-        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-    }
-
-    private void launchFilePicker() {
-        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-        intent.setType("image/*");
-        startActivityForResult(Intent.createChooser(intent, getString(R.string.select_thumbnail)),
-                MainActivity.REQUEST_FILE_PICKER);
-    }
-
-    private void checkStoragePermissionAndLaunchFilePicker() {
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this,
-                    new String[] { Manifest.permission.READ_EXTERNAL_STORAGE }, MainActivity.REQUEST_STORAGE_PERMISSION);
-        } else {
-            launchFilePicker();
-        }
-    }
-
-    private void openCameraSource() {
-        cameraSource.open(CameraCharacteristics.LENS_FACING_BACK);
     }
 
     private void checkCameraPermissionAndOpenCameraSource() {
@@ -425,263 +240,8 @@ public class GoLiveActivity extends AppCompatActivity {
         }
     }
 
-    private void showPrecheckError(String status) {
-        livestreamPrecheckView.setVisibility(View.VISIBLE);
-        imagePrecheckSpaceman.setImageResource(R.drawable.spaceman_sad);
-        textPrecheckStatus.setText(status);
-    }
-
-    private void signAndSetupStream() {
-        String hexData = Helper.toHexString(selectedChannel.getName());
-
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Map<String, Object> options = new HashMap<>(2);
-                    options.put("channel_id", selectedChannel.getClaimId());
-                    options.put("hexdata", hexData);
-
-                    AccountManager am = AccountManager.get(getApplicationContext());
-                    String authToken = am.peekAuthToken(Helper.getOdyseeAccount(am.getAccounts()), "auth_token_type");
-                    JSONObject result = (JSONObject) Lbry.authenticatedGenericApiCall("channel_sign", options, authToken);
-                    String signature = result.getString("signature");
-                    String signingTs = result.getString("signing_ts");
-                    if (!Helper.isNullOrEmpty(signature) && !Helper.isNullOrEmpty(signingTs)) {
-                        streamKey = createStreamKey(signature, signingTs);
-                    } else {
-                        new Handler(Looper.getMainLooper()).post(new Runnable() {
-                            @Override
-                            public void run() {
-                                livestreamControlsView.setVisibility(View.GONE);
-                                showPrecheckError(getString(R.string.stream_key_not_generated));
-                            }
-                        });
-                    }
-                } catch (ApiCallException | JSONException ex) {
-                    showError(ex.getMessage());
-                    new Handler(Looper.getMainLooper()).post(new Runnable() {
-                        @Override
-                        public void run() {
-                            livestreamControlsView.setVisibility(View.GONE);
-                            showPrecheckError(getString(R.string.error_publishing_livestream));
-                        }
-                    });
-                }
-            }
-        });
-        executor.shutdown();
-    }
-
-    // Poll every 30s waiting for claim to be confirmed before streaming
-    private void waitForConfirmation(String txid) {
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-
-        ((OdyseeApp) getApplication()).getScheduledExecutor().scheduleAtFixedRate(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Map<String, Object> options = new HashMap<>(2);
-                    options.put("type", Claim.TYPE_STREAM);
-                    options.put("txid", txid);
-
-                    AccountManager am = AccountManager.get(getApplicationContext());
-                    String authToken = am.peekAuthToken(Helper.getOdyseeAccount(am.getAccounts()), "auth_token_type");
-                    JSONObject result = (JSONObject) Lbry.authenticatedGenericApiCall(Lbry.METHOD_TXO_LIST, options, authToken);
-                    JSONObject item = result.getJSONArray("items").getJSONObject(0);
-                    int confirmations  = item.getInt("confirmations");
-                    if (confirmations > 0) {
-                        signAndSetupStream();
-
-                        runOnUiThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                progress.setVisibility(View.GONE);
-                                livestreamPrecheckView.setVisibility(View.GONE);
-                                livestreamControlsView.setVisibility(View.VISIBLE);
-                            }
-                        });
-                    }
-                } catch (ApiCallException | JSONException ex) {
-                    // Do nothing, will retry in 30s
-                    showError(ex.getMessage());
-                }
-            }
-        }, 0, 30, TimeUnit.SECONDS);
-    }
-
-    private Claim buildLivestreamClaim() {
-        Claim claim = new Claim();
-
-        claim.setName("livestream-" + System.currentTimeMillis());
-        claim.setAmount("0.01");
-
-        Claim.StreamMetadata metadata = new Claim.StreamMetadata();
-        metadata.setTitle(Helper.getValue(inputTitle.getText()));
-
-        claim.setSigningChannel(selectedChannel);
-
-        if (!Helper.isNullOrEmpty(uploadedThumbnailUrl)) {
-            Claim.Resource thumbnail = new Claim.Resource();
-            thumbnail.setUrl(uploadedThumbnailUrl);
-            metadata.setThumbnail(thumbnail);
-        } else {
-            // Use the channel thumbnail
-            String channelThumbnailUrl = Optional.ofNullable(selectedChannel.getValue())
-                    .map(Claim.GenericMetadata::getThumbnail)
-                    .map(Claim.Resource::getUrl)
-                    .orElse(null);
-            if (!Helper.isNullOrEmpty(channelThumbnailUrl)) {
-                metadata.setThumbnail(selectedChannel.getValue().getThumbnail());
-            }
-        }
-
-        claim.setValueType(Claim.TYPE_STREAM);
-        claim.setValue(metadata);
-
-        return claim;
-    }
-
-    private void publishLivestreamClaim() {
-        Claim claim = buildLivestreamClaim();
-        AccountManager am = AccountManager.get(this);
-        String authToken = am.peekAuthToken(Helper.getOdyseeAccount(am.getAccounts()), "auth_token_type");
-        PublishClaimTask task = new PublishClaimTask(claim, null, authToken, new ClaimResultHandler() {
-            @Override
-            public void beforeStart() { }
-
-            @Override
-            public void onSuccess(Claim claimResult) {
-                String txid = claimResult.getTxid();
-                waitForConfirmation(txid);
-            }
-
-            @Override
-            public void onError(Exception error) {
-                if (error != null) {
-                    showError(error.getMessage());
-                }
-                progress.setVisibility(View.GONE);
-                livestreamControlsView.setVisibility(View.GONE);
-                showPrecheckError(getString(R.string.error_publishing_livestream));
-            }
-        });
-        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-    }
-
-    /**
-     * Checks if it's possible to stream on {@code channel}, and update the
-     * error text with the reason if not.
-     *
-     * @param channel The channel to check
-     * @return True if it's possible to stream on the channel, false otherwise
-     */
-    private boolean checkCanStreamOnChannel(Claim channel) {
-        if (channel == null || channel.isPlaceholder() || channel.isPlaceholderAnonymous()) {
-            return false;
-        }
-
-        if (channel.getConfirmations() < 1) {
-            textChannelError.setText(getString(R.string.channel_error_pending));
-            textChannelError.setVisibility(View.VISIBLE);
-            return false;
-        }
-
-        // Disabled due to lack of server side checking for now
-//        double effectiveAmount = Double.parseDouble(channel.getMeta().getEffectiveAmount());
-//        if (effectiveAmount < MIN_STREAM_STAKE) {
-//            textChannelError.setText(getString(R.string.channel_error_need_minimum_credits,
-//                    MIN_STREAM_STAKE, channel.getName()));
-//            textChannelError.setVisibility(View.VISIBLE);
-//            return false;
-//        }
-
-        textChannelError.setVisibility(View.GONE);
-        return true;
-    }
-
-    private void showLivestreamingOptions() {
-        progress.setVisibility(View.GONE);
-        livestreamPrecheckView.setVisibility(View.GONE);
-        livestreamOptionsView.setVisibility(View.VISIBLE);
-
-        checkCanStreamOnChannel((Claim) selectChannelSpinner.getSelectedItem());
-    }
-
-    private void updateChannelList(List<Claim> channels) {
-        selectChannelSpinner.setAdapter(new InlineChannelSpinnerAdapter(this, R.layout.spinner_item_channel, channels));
-
-        if (channels.size() > 0) {
-            showLivestreamingOptions();
-        } else {
-            progress.setVisibility(View.GONE);
-            showPrecheckError(getString(R.string.precheck_need_channel));
-        }
-    }
-
-    private void fetchChannels() {
-        if (Lbry.ownChannels != null && Lbry.ownChannels.size() > 0) {
-            updateChannelList(Lbry.ownChannels);
-            return;
-        }
-
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
-            Supplier<List<Claim>> s = new ClaimListSupplier(Collections.singletonList(Claim.TYPE_CHANNEL), null);
-            CompletableFuture<List<Claim>> cf = CompletableFuture.supplyAsync(s, ((OdyseeApp) getApplication()).getExecutor());
-            cf.whenComplete((result, e) -> {
-                if (e != null) {
-                    runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            Throwable t = e.getCause();
-                            if (t != null) {
-                                showError(t.getMessage());
-                            }
-                            progress.setVisibility(View.GONE);
-                            showPrecheckError(getString(R.string.precheck_error_loading_channels));
-                        }
-                    });
-                }
-
-                if (result != null) {
-                    runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            Lbry.ownChannels = new ArrayList<>(result);
-                            updateChannelList(Lbry.ownChannels);
-                        }
-                    });
-                }
-            });
-        } else {
-            Map<String, Object> options = Lbry.buildClaimListOptions(Claim.TYPE_CHANNEL, 1, 999, true);
-            ClaimListTask task = new ClaimListTask(options, null, new ClaimListResultHandler() {
-                @Override
-                public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
-                    Lbry.ownChannels = new ArrayList<>(claims);
-                    updateChannelList(Lbry.ownChannels);
-                }
-
-                @Override
-                public void onError(Exception error) {
-                    if (error != null) {
-                        showError(error.getMessage());
-                    }
-                    progress.setVisibility(View.GONE);
-                    showPrecheckError(getString(R.string.precheck_error_loading_channels));
-                }
-            });
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-        }
-    }
-
-    private String createStreamKey(String signature, String signingTs) {
-        String hexData = Helper.toHexString(selectedChannel.getName());
-        return selectedChannel.getClaimId()
-                + "?d=" + hexData
-                + "&s=" + signature
-                + "&t=" + signingTs;
+    private void openCameraSource() {
+        cameraSource.open(CameraCharacteristics.LENS_FACING_BACK);
     }
 
     private void showError(String message) {

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -46,9 +46,10 @@ import android.util.Log;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.Menu;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.WindowInsets;
@@ -64,6 +65,7 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.ListView;
+import android.widget.PopupMenu;
 import android.widget.PopupWindow;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -234,6 +236,8 @@ import com.odysee.app.ui.BaseFragment;
 import com.odysee.app.ui.findcontent.FileViewFragment;
 import com.odysee.app.ui.findcontent.FollowingFragment;
 import com.odysee.app.ui.other.CreatorSettingsFragment;
+import com.odysee.app.ui.publish.GoLiveFormFragment;
+import com.odysee.app.ui.publish.LivestreamsFragment;
 import com.odysee.app.ui.rewards.RewardVerificationFragment;
 import com.odysee.app.ui.library.LibraryFragment;
 import com.odysee.app.ui.library.PlaylistFragment;
@@ -373,6 +377,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public static final String ACTION_NOW_PLAYING_CLAIM_UPDATED = "com.odysee.app.Broadcast.NowPlayingClaimUpdated";
     public static final String ACTION_NOW_PLAYING_CLAIM_CLEARED = "com.odysee.app.Broadcast.NowPlayingClaimCleared";
     public static final String ACTION_PUBLISH_SUCCESSFUL = "com.odysee.app.Broadcast.PublishSuccessful";
+    public static final String ACTION_LIVESTREAM_PUBLISH_SUCCESSFUL = "com.odysee.app.Broadcast.LivestreamPublishSuccessful";
     public static final String ACTION_OPEN_ALL_CONTENT_TAG = "com.odysee.app.Broadcast.OpenAllContentTag";
     public static final String ACTION_WALLET_BALANCE_UPDATED = "com.odysee.app.Broadcast.WalletBalanceUpdated";
     public static final String ACTION_OPEN_CHANNEL_URL = "com.odysee.app.Broadcast.OpenChannelUrl";
@@ -792,7 +797,23 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     return;
                 }
 
-                showPublishFlow();
+                PopupMenu popup = new PopupMenu(MainActivity.this, view);
+                MenuInflater inflater = popup.getMenuInflater();
+                inflater.inflate(R.menu.menu_upload, popup.getMenu());
+                popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+                    @Override
+                    public boolean onMenuItemClick(MenuItem item) {
+                        if (item.getItemId() == R.id.action_upload) {
+                            showPublishFlow();
+                            return true;
+                        } else if (item.getItemId() == R.id.action_go_live) {
+                            showGoLiveFlow();
+                            return true;
+                        }
+                        return false;
+                    }
+                });
+                popup.show();
             }
         });
 
@@ -989,7 +1010,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 View buttonChangeDefaultChannel = customView.findViewById(R.id.button_change_default_channel);
                 View defaultChannelListParent = customView.findViewById(R.id.default_channel_list_layout);
                 ListView defaultChannelList = customView.findViewById(R.id.default_channel_list);
-                View buttonGoLive = customView.findViewById(R.id.button_go_live);
+                View buttonLivestreams = customView.findViewById(R.id.button_livestreams);
                 View buttonChannels = customView.findViewById(R.id.button_channels);
                 View buttonCreatorSettings = customView.findViewById(R.id.button_creator_settings);
                 View buttonPublishes = customView.findViewById(R.id.button_publishes);
@@ -1003,10 +1024,10 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 Account odyseeAccount = Helper.getOdyseeAccount(am.getAccounts());
                 final boolean isSignedIn = odyseeAccount != null;
 
-                buttonGoLive.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
                 buttonChannels.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
                 buttonCreatorSettings.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
                 buttonPublishes.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
+                buttonLivestreams.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
                 buttonShowRewards.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
                 buttonYouTubeSync.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
                 buttonSignOut.setVisibility(isSignedIn ? View.VISIBLE : View.GONE);
@@ -1087,8 +1108,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                             defaultChannelList.requestLayout();
 
                             buttonChannels.setVisibility(View.GONE);
-                            buttonGoLive.setVisibility(View.GONE);
                             buttonPublishes.setVisibility(View.GONE);
+                            buttonLivestreams.setVisibility(View.GONE);
                             buttonShowRewards.setVisibility(View.GONE);
                             customView.findViewById(R.id.button_help_support).setVisibility(View.GONE);
                             customView.findViewById(R.id.button_app_settings).setVisibility(View.GONE);
@@ -1100,8 +1121,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         } else {
                             TransitionManager.beginDelayedTransition((ViewGroup) popupWindow.getContentView());
                             buttonChannels.setVisibility(View.VISIBLE);
-                            buttonGoLive.setVisibility(View.VISIBLE);
                             buttonPublishes.setVisibility(View.VISIBLE);
+                            buttonLivestreams.setVisibility(View.VISIBLE);
                             buttonShowRewards.setVisibility(View.VISIBLE);
                             customView.findViewById(R.id.button_help_support).setVisibility(View.VISIBLE);
                             customView.findViewById(R.id.button_app_settings).setVisibility(View.VISIBLE);
@@ -1124,14 +1145,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     }
                 });
 
-                buttonGoLive.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        popupWindow.dismiss();
-                        hideNotifications();
-                        startActivity(new Intent(MainActivity.this, GoLiveActivity.class));
-                    }
-                });
                 buttonChannels.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -1154,6 +1167,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         popupWindow.dismiss();
                         hideNotifications();
                         openFragment(PublishesFragment.class, true, null);
+                    }
+                });
+                buttonLivestreams.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        popupWindow.dismiss();
+                        hideNotifications();
+                        openFragment(LivestreamsFragment.class, true, null);
                     }
                 });
                 buttonShowRewards.setOnClickListener(new View.OnClickListener() {
@@ -1292,9 +1313,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         // Show PublishFragment.class
         clearPlayingPlayer();
         hideNotifications(); // Avoid showing Notifications fragment when clicking Publish when Notification panel is opened
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        fragmentManager.beginTransaction().replace(R.id.main_activity_other_fragment, new PublishFragment(), "PUBLISH").addToBackStack("publish_claim").commit();
-        findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);
+        openFragment(PublishFragment.class, true, null);
+        hideActionBar();
+    }
+
+    private void showGoLiveFlow() {
+        clearPlayingPlayer();
+        hideNotifications();
+        openFragment(GoLiveFormFragment.class, true, null);
         hideActionBar();
     }
 
@@ -1568,7 +1594,27 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             public void run() {
                 try {
                     getSupportFragmentManager().popBackStack();
+                    getSupportFragmentManager().popBackStack(); // Pop PublishFragment (video picker)
                     openFragment(PublishesFragment.class, true, null);
+                } catch (IllegalStateException ex) {
+                    // pass
+                    try {
+                        onBackPressed();
+                    } catch (IllegalStateException iex) {
+                        // if this fails on some devices. what's the solution?
+                    }
+                }
+            }
+        });
+    }
+
+    public void openLivestreamsOnSuccessfulLivestreamPublish(Intent receivedIntent) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    getSupportFragmentManager().popBackStack();
+                    openFragment(LivestreamsFragment.class, true, null);
                 } catch (IllegalStateException ex) {
                     // pass
                     try {
@@ -1587,6 +1633,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             params.put("claim", claim);
         }
         openFragment(PublishFormFragment.class, true, params);
+    }
+
+    public void openGoLiveForm(Claim claim) {
+        Map<String, Object> params = new HashMap<>();
+        if (claim != null) {
+            params.put("claim", claim);
+        }
+        openFragment(GoLiveFormFragment.class, true, params);
     }
 
     public void openChannelUrl(String url, String source) {
@@ -3501,6 +3555,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         intentFilter.addAction(ACTION_OPEN_WALLET_PAGE);
         intentFilter.addAction(ACTION_OPEN_REWARDS_PAGE);
         intentFilter.addAction(ACTION_PUBLISH_SUCCESSFUL);
+        intentFilter.addAction(ACTION_LIVESTREAM_PUBLISH_SUCCESSFUL);
         intentFilter.addAction(ACTION_SAVE_SHARED_USER_STATE);
         intentFilter.addAction(LbrynetMessagingService.ACTION_NOTIFICATION_RECEIVED);
         requestsReceiver = new BroadcastReceiver() {
@@ -3517,6 +3572,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     saveSharedUserState();
                 } else if (ACTION_PUBLISH_SUCCESSFUL.equalsIgnoreCase(action)) {
                     openPublishesOnSuccessfulPublish();
+                } else if (ACTION_LIVESTREAM_PUBLISH_SUCCESSFUL.equalsIgnoreCase(action)) {
+                    openLivestreamsOnSuccessfulLivestreamPublish(intent);
                 } else if (LbrynetMessagingService.ACTION_NOTIFICATION_RECEIVED.equalsIgnoreCase(action)) {
                     handleNotificationReceived(intent);
                 }

--- a/app/src/main/java/com/odysee/app/adapter/ReplaysPagerAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ReplaysPagerAdapter.java
@@ -1,0 +1,97 @@
+package com.odysee.app.adapter;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+
+import com.odysee.app.model.LivestreamReplay;
+import com.odysee.app.ui.publish.ReplaysPageFragment;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ReplaysPagerAdapter extends FragmentStateAdapter {
+    private static final int PAGE_SIZE = 4;
+
+    private final List<LivestreamReplay> replays;
+    private final SelectedReplayManager manager;
+
+    // Needed because default getItemId() uses position so fragments
+    // don't get changed when calling notifyDataSetChanged().
+    private long idCounter = 0;
+    private List<Long> itemIds;
+
+    public ReplaysPagerAdapter(FragmentActivity activity, List<LivestreamReplay> replays, SelectedReplayManager manager) {
+        super(activity);
+        this.replays = replays;
+        this.manager = manager;
+
+        LivestreamReplay selectedReplay = manager.getSelectedReplay();
+        if (selectedReplay != null) {
+            for (LivestreamReplay replay : replays) {
+                if (replay.getUrl().equals(selectedReplay.getUrl())) {
+                    replay.setSelected(true);
+                }
+            }
+        }
+
+        this.itemIds = generateItemIds();
+        RecyclerView.AdapterDataObserver observer = new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                itemIds = generateItemIds();
+            }
+        };
+        registerAdapterDataObserver(observer);
+    }
+
+    private List<Long> generateItemIds() {
+        return IntStream.range(0, getItemCount())
+                .mapToObj(unused -> idCounter++)
+                .collect(Collectors.toList());
+    }
+
+    @NonNull
+    @Override
+    public Fragment createFragment(int position) {
+        ReplaysPageFragment fragment = new ReplaysPageFragment();
+        fragment.setReplays(replays.subList(
+                position * 4, Math.min((position * 4) + 4, replays.size())));
+        fragment.setListener(new ReplaysPageFragment.ReplaySelectedListener() {
+            @Override
+            public void onReplaySelected(LivestreamReplay replay) {
+                LivestreamReplay selectedReplay = manager.getSelectedReplay();
+                if (selectedReplay != null) {
+                    selectedReplay.setSelected(false);
+                }
+                replay.setSelected(true);
+                manager.setSelectedReplay(replay);
+                notifyDataSetChanged();
+            }
+        });
+        return fragment;
+    }
+
+    @Override
+    public int getItemCount() {
+        return (int) Math.ceil(replays.size() / (double) PAGE_SIZE);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return itemIds.get(position);
+    }
+
+    @Override
+    public boolean containsItem(long itemId) {
+        return itemIds.contains(itemId);
+    }
+
+    public interface SelectedReplayManager {
+        LivestreamReplay getSelectedReplay();
+        void setSelectedReplay(LivestreamReplay replay);
+    }
+}

--- a/app/src/main/java/com/odysee/app/model/LivestreamReplay.java
+++ b/app/src/main/java/com/odysee/app/model/LivestreamReplay.java
@@ -1,0 +1,35 @@
+package com.odysee.app.model;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+
+import org.json.JSONObject;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class LivestreamReplay {
+    private String status;
+    private String percentComplete;
+    @SerializedName("URL")
+    private String url;
+    @SerializedName("ThumbnailURLs")
+    private List<String> thumbnailUrls;
+    private long duration;
+    private Date created;
+
+    public boolean selected;
+
+    public static LivestreamReplay fromJSONObject(JSONObject replayObject) {
+        String replayJson = replayObject.toString();
+
+        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE).create();
+
+        return gson.fromJson(replayJson, LivestreamReplay.class);
+    }
+}

--- a/app/src/main/java/com/odysee/app/tasks/LivestreamReplaysResultHandler.java
+++ b/app/src/main/java/com/odysee/app/tasks/LivestreamReplaysResultHandler.java
@@ -1,0 +1,10 @@
+package com.odysee.app.tasks;
+
+import com.odysee.app.model.LivestreamReplay;
+
+import java.util.List;
+
+public interface LivestreamReplaysResultHandler {
+    void onSuccess(List<LivestreamReplay> replays);
+    void onError(Exception error);
+}

--- a/app/src/main/java/com/odysee/app/tasks/LivestreamReplaysTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/LivestreamReplaysTask.java
@@ -1,0 +1,106 @@
+package com.odysee.app.tasks;
+
+import android.os.AsyncTask;
+import android.view.View;
+
+import com.odysee.app.exceptions.ApiCallException;
+import com.odysee.app.model.Claim;
+import com.odysee.app.model.LivestreamReplay;
+import com.odysee.app.utils.Helper;
+import com.odysee.app.utils.Lbry;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+public class LivestreamReplaysTask extends AsyncTask<Void, Void, List<LivestreamReplay>> {
+    private static final String ODYSEE_LIVESTREAM_REPLAYS_LIST_API = "https://api.odysee.live/replays/list?channel_claim_id=%s&signature=%s&signature_ts=%s&channel_name=%s";
+
+    private final Claim channel;
+    private final View progressView;
+    private final String authToken;
+    private final LivestreamReplaysResultHandler handler;
+    private Exception error;
+
+    public LivestreamReplaysTask(Claim channel, View progressView, String token, LivestreamReplaysResultHandler handler) {
+        this.channel = channel;
+        this.progressView = progressView;
+        this.authToken = token;
+        this.handler = handler;
+    }
+
+    @Override
+    protected void onPreExecute() {
+        Helper.setViewVisibility(progressView, View.VISIBLE);
+    }
+
+    @Override
+    protected List<LivestreamReplay> doInBackground(Void... params) {
+        try {
+            // Sign channel data
+            Map<String, Object> options = new HashMap<>(2);
+            options.put("channel_id", channel.getClaimId());
+            options.put("hexdata", Helper.toHexString(channel.getName()));
+
+            JSONObject result = (JSONObject) Lbry.authenticatedGenericApiCall(
+                    "channel_sign", options, authToken);
+            String signature = result.getString("signature");
+            String signingTs = result.getString("signing_ts");
+
+            // Fetch replays
+            OkHttpClient client = new OkHttpClient();
+            String url = String.format(ODYSEE_LIVESTREAM_REPLAYS_LIST_API,
+                    channel.getClaimId(), signature, signingTs, channel.getName());
+            Request request = new Request.Builder().url(url).build();
+
+            List<LivestreamReplay> replays = null;
+
+            try (Response response = client.newCall(request).execute()) {
+                ResponseBody body = response.body();
+                int responseCode = response.code();
+                if (body != null && responseCode >= 200 && responseCode < 300) {
+                    String responseString = body.string();
+                    JSONObject responseJson = new JSONObject(responseString);
+                    JSONArray data = responseJson.getJSONArray("data");
+                    replays = new ArrayList<>(data.length());
+                    for (int i = 0; i < data.length(); i++) {
+                        JSONObject replayJson = data.getJSONObject(i);
+                        LivestreamReplay replay = LivestreamReplay.fromJSONObject(replayJson);
+
+                        if (replay.getStatus().equals("inprogress") || replay.getStatus().equals("ready")) {
+                            replays.add(replay);
+                        }
+                    }
+                }
+            }
+
+            return replays;
+        } catch (ApiCallException | JSONException | IOException ex) {
+            error = ex;
+            return null;
+        }
+    }
+
+    @Override
+    protected void onPostExecute(List<LivestreamReplay> replays) {
+        Helper.setViewVisibility(progressView, View.GONE);
+        if (handler != null) {
+            if (replays != null) {
+                handler.onSuccess(replays);
+            } else {
+                handler.onError(error);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/odysee/app/tasks/claim/PublishClaimTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/claim/PublishClaimTask.java
@@ -7,12 +7,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import com.odysee.app.exceptions.ApiCallException;
@@ -33,53 +27,20 @@ public class PublishClaimTask extends AsyncTask<Void, Void, Claim> {
         this.authToken = authToken;
         this.handler = handler;
     }
+
+    @Override
     protected void onPreExecute() {
         Helper.setViewVisibility(progressView, View.VISIBLE);
         if (handler != null) {
             handler.beforeStart();
         }
     }
+
+    @Override
     protected Claim doInBackground(Void... params) {
-        Claim.StreamMetadata metadata = (Claim.StreamMetadata) claim.getValue();
-        DecimalFormat amountFormat = new DecimalFormat(Helper.SDK_AMOUNT_FORMAT, new DecimalFormatSymbols(Locale.US));
-
-        Map<String, Object> options = new HashMap<>();
-        options.put("blocking", true);
-        options.put("name", claim.getName());
-        options.put("bid", amountFormat.format(new BigDecimal(claim.getAmount()).doubleValue()));
-        options.put("title", Helper.isNullOrEmpty(claim.getTitle()) ? "" : claim.getTitle());
-        options.put("description", Helper.isNullOrEmpty(claim.getDescription()) ? "" : claim.getDescription());
-        options.put("thumbnail_url", Helper.isNullOrEmpty(claim.getThumbnailUrl()) ? "" : claim.getThumbnailUrl());
-
-        if (claim.getTags() != null && claim.getTags().size() > 0) {
-            options.put("tags", new ArrayList<>(claim.getTags()));
-        }
-        if (metadata.getFee() != null) {
-            options.put("fee_currency", metadata.getFee().getCurrency());
-            options.put("fee_amount", amountFormat.format(new BigDecimal(metadata.getFee().getAmount()).doubleValue()));
-        }
-        if (claim.getSigningChannel() != null) {
-            options.put("channel_id", claim.getSigningChannel().getClaimId());
-        }
-        if (metadata.getLanguages() != null && metadata.getLanguages().size() > 0) {
-            options.put("languages", metadata.getLanguages());
-        }
-        if (!Helper.isNullOrEmpty(metadata.getLicense())) {
-            options.put("license", metadata.getLicense());
-        }
-        if (!Helper.isNullOrEmpty(metadata.getLicenseUrl())) {
-            options.put("license_url", metadata.getLicenseUrl());
-        }
-
-        if (metadata.getReleaseTime() > 0) {
-            options.put("release_time", metadata.getReleaseTime());
-        } else if (claim.getTimestamp() > 0) {
-            options.put("release_time", claim.getTimestamp());
-        } else {
-            options.put("release_time", Double.valueOf(Math.floor(System.currentTimeMillis() / 1000.0)).intValue());
-        }
-
+        Map<String, Object> options = Helper.buildPublishOptions(claim);
         Claim claimResult = null;
+
         try {
             JSONObject result = (JSONObject) Lbry.authenticatedGenericApiCall(Lbry.METHOD_PUBLISH, options, authToken);
             if (result.has("outputs")) {
@@ -92,13 +53,14 @@ public class PublishClaimTask extends AsyncTask<Void, Void, Claim> {
                     }
                 }
             }
-        } catch (ApiCallException | ClassCastException | JSONException ex) {
+        } catch (ApiCallException | JSONException ex) {
             error = ex;
         }
 
         return claimResult;
-
     }
+
+    @Override
     protected void onPostExecute(Claim result) {
         Helper.setViewVisibility(progressView, View.GONE);
         if (handler != null) {

--- a/app/src/main/java/com/odysee/app/tasks/claim/ReplayPublishTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/claim/ReplayPublishTask.java
@@ -1,0 +1,116 @@
+package com.odysee.app.tasks.claim;
+
+import android.os.AsyncTask;
+import android.view.View;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.odysee.app.exceptions.LbryResponseException;
+import com.odysee.app.model.Claim;
+import com.odysee.app.utils.Helper;
+import com.odysee.app.utils.Lbry;
+
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+public class ReplayPublishTask extends AsyncTask<Void, Void, Claim> {
+    private static final String PUBLISH_ENDPOINT = "https://publish.na-backend.odysee.com/v1";
+
+    private final Claim claim;
+    private final String remoteUrl;
+    private final View progressView;
+    private final String authToken;
+    private final ClaimResultHandler handler;
+    private Exception error;
+
+    public ReplayPublishTask(Claim claim, String remoteUrl, View progressView, String authToken, ClaimResultHandler handler) {
+        this.claim = claim;
+        this.remoteUrl = remoteUrl;
+        this.progressView = progressView;
+        this.authToken = authToken;
+        this.handler = handler;
+    }
+
+    @Override
+    protected void onPreExecute() {
+        Helper.setViewVisibility(progressView, View.VISIBLE);
+        if (handler != null) {
+            handler.beforeStart();
+        }
+    }
+
+    @Override
+    protected Claim doInBackground(Void... params) {
+        Map<String, Object> options = Helper.buildPublishOptions(claim);
+        Claim claimResult = null;
+
+        try {
+            JSONObject lbryParams = Lbry.buildJsonParams(options);
+            JSONObject jsonPayload = new JSONObject();
+            jsonPayload.put("jsonrpc", "2.0");
+            jsonPayload.put("method", Lbry.METHOD_PUBLISH);
+            jsonPayload.put("params", lbryParams);
+            jsonPayload.put("id", System.currentTimeMillis());
+
+            MultipartBody.Builder multipartBuilder = new MultipartBody.Builder()
+                    .setType(Helper.FORM_DATA_MEDIA_TYPE)
+                    .addFormDataPart("json_payload", jsonPayload.toString());
+
+            if (remoteUrl != null) {
+                multipartBuilder.addFormDataPart("remote_url", remoteUrl);
+            }
+
+            RequestBody body = multipartBuilder.build();
+            Request request = new Request.Builder()
+                    .url(new URL(PUBLISH_ENDPOINT))
+                    .post(body)
+                    .addHeader("X-Lbry-Auth-Token", authToken)
+                    .build();
+            OkHttpClient client = new OkHttpClient.Builder()
+                    .writeTimeout(300, TimeUnit.SECONDS)
+                    .readTimeout(300, TimeUnit.SECONDS)
+                    .build();
+
+            Response response = client.newCall(request).execute();
+            JSONObject result = (JSONObject) Lbry.parseResponse(response);
+            if (result.has("outputs")) {
+                JSONArray outputs = result.getJSONArray("outputs");
+                for (int i = 0; i < outputs.length(); i++) {
+                    JSONObject output = outputs.getJSONObject(i);
+                    if (output.has("claim_id") && output.has("claim_op")) {
+                        claimResult = Claim.claimFromOutput(output);
+                        break;
+                    }
+                }
+            }
+        } catch (IOException | LbryResponseException | JSONException ex) {
+            error = ex;
+            return null;
+        }
+
+        return claimResult;
+    }
+
+    @Override
+    protected void onPostExecute(Claim result) {
+        Helper.setViewVisibility(progressView, View.GONE);
+        if (handler != null) {
+            if (result != null) {
+                handler.onSuccess(result);
+            } else {
+                handler.onError(error);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/odysee/app/tasks/claim/TusPublishTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/claim/TusPublishTask.java
@@ -87,39 +87,7 @@ public class TusPublishTask extends AsyncTask<Void, Void, Void> {
                     URL notifyURL = new URL(uploader.getUploadURL().toString() + "/notify");
                     JSONObject requestBody = new JSONObject();
                     try {
-                        Claim.StreamMetadata metadata = (Claim.StreamMetadata) claim.getValue();
-                        DecimalFormat amountFormat = new DecimalFormat(Helper.SDK_AMOUNT_FORMAT, new DecimalFormatSymbols(Locale.US));
-
-                        Map<String, Object> options = new HashMap<>();
-                        options.put("blocking", true);
-                        options.put("name", claim.getName());
-                        options.put("bid", amountFormat.format(new BigDecimal(claim.getAmount()).doubleValue()));
-                        options.put("title", Helper.isNullOrEmpty(claim.getTitle()) ? "" : claim.getTitle());
-                        options.put("description", Helper.isNullOrEmpty(claim.getDescription()) ? "" : claim.getDescription());
-                        options.put("thumbnail_url", Helper.isNullOrEmpty(claim.getThumbnailUrl()) ? "" : claim.getThumbnailUrl());
-                        if (claim.getTags() != null && claim.getTags().size() > 0) {
-                            options.put("tags", new ArrayList<>(claim.getTags()));
-                        }
-                        if (claim.getSigningChannel() != null) {
-                            options.put("channel_id", claim.getSigningChannel().getClaimId());
-                        }
-                        if (metadata.getLanguages() != null && metadata.getLanguages().size() > 0) {
-                            options.put("languages", metadata.getLanguages());
-                        }
-                        if (!Helper.isNullOrEmpty(metadata.getLicense())) {
-                            options.put("license", metadata.getLicense());
-                        }
-                        if (!Helper.isNullOrEmpty(metadata.getLicenseUrl())) {
-                            options.put("license_url", metadata.getLicenseUrl());
-                        }
-
-                        if (metadata.getReleaseTime() > 0) {
-                            options.put("release_time", metadata.getReleaseTime());
-                        } else if (claim.getTimestamp() > 0) {
-                            options.put("release_time", claim.getTimestamp());
-                        } else {
-                            options.put("release_time", Double.valueOf(Math.floor(System.currentTimeMillis() / 1000.0)).intValue());
-                        }
+                        Map<String, Object> options = Helper.buildPublishOptions(claim);
 
                         JSONObject params = Lbry.buildJsonParams(options);
                         long counter = Double.valueOf(System.currentTimeMillis() / 1000.0).longValue();

--- a/app/src/main/java/com/odysee/app/ui/publish/GoLiveFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/GoLiveFormFragment.java
@@ -1,0 +1,1284 @@
+package com.odysee.app.ui.publish;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.text.format.DateFormat;
+import android.text.format.DateUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatSpinner;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewpager2.widget.ViewPager2;
+
+import com.bumptech.glide.Glide;
+import com.google.android.flexbox.FlexboxLayoutManager;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.button.MaterialButtonToggleGroup;
+import com.google.android.material.datepicker.CalendarConstraints;
+import com.google.android.material.datepicker.DateValidatorPointForward;
+import com.google.android.material.datepicker.MaterialDatePicker;
+import com.google.android.material.datepicker.MaterialPickerOnPositiveButtonClickListener;
+import com.google.android.material.tabs.TabLayout;
+import com.google.android.material.tabs.TabLayoutMediator;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.timepicker.MaterialTimePicker;
+import com.google.android.material.timepicker.TimeFormat;
+import com.odysee.app.BuildConfig;
+import com.odysee.app.MainActivity;
+import com.odysee.app.R;
+import com.odysee.app.adapter.InlineChannelSpinnerAdapter;
+import com.odysee.app.adapter.LanguageSpinnerAdapter;
+import com.odysee.app.adapter.LicenseSpinnerAdapter;
+import com.odysee.app.adapter.ReplaysPagerAdapter;
+import com.odysee.app.adapter.TagListAdapter;
+import com.odysee.app.listener.FilePickerListener;
+import com.odysee.app.listener.StoragePermissionListener;
+import com.odysee.app.listener.WalletBalanceListener;
+import com.odysee.app.model.Claim;
+import com.odysee.app.model.Language;
+import com.odysee.app.model.License;
+import com.odysee.app.model.LivestreamReplay;
+import com.odysee.app.model.Tag;
+import com.odysee.app.model.WalletBalance;
+import com.odysee.app.tasks.LivestreamReplaysResultHandler;
+import com.odysee.app.tasks.LivestreamReplaysTask;
+import com.odysee.app.tasks.UpdateSuggestedTagsTask;
+import com.odysee.app.tasks.UploadImageTask;
+import com.odysee.app.tasks.claim.ClaimListResultHandler;
+import com.odysee.app.tasks.claim.ClaimListTask;
+import com.odysee.app.tasks.claim.ClaimResultHandler;
+import com.odysee.app.tasks.claim.PublishClaimTask;
+import com.odysee.app.tasks.claim.ReplayPublishTask;
+import com.odysee.app.tasks.lbryinc.LogPublishTask;
+import com.odysee.app.ui.BaseFragment;
+import com.odysee.app.ui.channel.ChannelCreateDialogFragment;
+import com.odysee.app.utils.Helper;
+import com.odysee.app.utils.Lbry;
+import com.odysee.app.utils.LbryAnalytics;
+import com.odysee.app.utils.LbryUri;
+import com.odysee.app.utils.Lbryio;
+import com.odysee.app.utils.Predefined;
+import com.odysee.app.utils.Utils;
+
+import java.io.File;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class GoLiveFormFragment extends BaseFragment implements
+        FilePickerListener, StoragePermissionListener, TagListAdapter.TagClickListener,
+        WalletBalanceListener, ChannelCreateDialogFragment.ChannelCreateListener {
+    private static final int SUGGESTED_TAGS_LIMIT = 8;
+    private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+    private static final String SCHEDULED_LIVESTREAM_TAG = "c:scheduled-livestream";
+
+    private ScrollView scrollView;
+
+    private TextInputEditText inputTitle;
+    private TextInputEditText inputAddress;
+    private TextInputEditText inputDescription;
+    private TextInputEditText inputTagFilter;
+    private TextInputEditText inputOtherLicenseDescription;
+    private TextInputEditText inputDeposit;
+
+    private TextView textAddressChannel;
+    private TextView textInlineAddressInvalid;
+    private TextView textDateInfo;
+    private TextView textReplaysTitle;
+    private TextView textInlineDepositBalance;
+    private TextView textReleaseTimePastNotAllowed;
+
+    private TextView linkShowExtraFields;
+    private TextView linkReleaseDate;
+    private TextView linkReleaseTime;
+    private TextView linkCancel;
+
+    private ImageView imageThumbnail;
+
+    private MaterialButtonToggleGroup createModeToggleGroup;
+    private MaterialButtonToggleGroup dateToggleGroup;
+
+    private MaterialButton buttonReleaseTimeDefault;
+    private MaterialButton buttonCreate;
+
+    private ImageButton buttonReloadReplays;
+
+    private View noTagsView;
+    private View noTagResultsView;
+    private View mediaContainer;
+    private View progressThumbnailUploading;
+    private View progressLoadingChannels;
+    private View progressLoadingReplays;
+    private View progressCreating;
+    private View layoutLivestreamDate;
+    private View layoutScheduledPicker;
+    private View layoutLivestreamReplays;
+    private View layoutLivestreamReplaysList;
+    private View layoutExtraFields;
+    private View layoutOtherLicenseDescription;
+    private View inlineDepositBalanceContainer;
+
+    private AppCompatSpinner channelSpinner;
+    private AppCompatSpinner languageSpinner;
+    private AppCompatSpinner licenseSpinner;
+
+    private RecyclerView suggestedTagsList;
+
+    private ViewPager2 replaysViewPager;
+
+    private TabLayout replaysTabLayout;
+
+    private TagListAdapter addedTagsAdapter;
+    private TagListAdapter suggestedTagsAdapter;
+
+    private InlineChannelSpinnerAdapter channelSpinnerAdapter;
+
+    private ReplaysPagerAdapter replaysAdapter;
+
+    // In progress variables
+    private boolean launchPickerPending;
+    private boolean uploadingThumbnail;
+    private boolean fetchingChannels;
+    private boolean saveInProgress;
+
+    // State variables
+    private String lastSelectedThumbnailFile;
+    private String uploadedThumbnailUrl;
+    private boolean storageRefusedOnce;
+    private boolean editFieldsLoaded;
+    private boolean editChannelSpinnerLoaded;
+    private boolean editMode;
+    private boolean modeLivestream = true;
+    private boolean anytimeStream = true;
+    private Claim currentClaim;
+    private String currentTagFilter;
+    private LivestreamReplay selectedLivestreamReplay;
+    private long releaseDateMillis = Long.MIN_VALUE;
+    private int releaseTimeHours = -1;
+    private int releaseTimeMinutes = -1;
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_go_live_form, container, false);
+
+        scrollView = root.findViewById(R.id.go_live_form_scroll_view);
+
+        inputTitle = root.findViewById(R.id.go_live_form_input_title);
+        inputAddress = root.findViewById(R.id.go_live_form_input_address);
+        inputDescription = root.findViewById(R.id.go_live_form_input_description);
+        inputTagFilter = root.findViewById(R.id.form_tag_filter_input);
+        inputOtherLicenseDescription = root.findViewById(R.id.go_live_form_input_license_other);
+        inputDeposit = root.findViewById(R.id.go_live_form_input_deposit);
+
+        textAddressChannel = root.findViewById(R.id.go_live_form_address_channel);
+        textInlineAddressInvalid = root.findViewById(R.id.go_live_form_inline_address_invalid);
+        textDateInfo = root.findViewById(R.id.go_live_form_date_info);
+        textReplaysTitle = root.findViewById(R.id.go_live_form_replays_title);
+        textInlineDepositBalance = root.findViewById(R.id.go_live_form_inline_balance_value);
+        textReleaseTimePastNotAllowed = root.findViewById(R.id.go_live_form_release_time_past_not_allowed);
+
+        linkShowExtraFields = root.findViewById(R.id.go_live_form_toggle_extra);
+        linkReleaseDate = root.findViewById(R.id.go_live_form_release_date);
+        linkReleaseTime = root.findViewById(R.id.go_live_form_release_time);
+        linkCancel = root.findViewById(R.id.go_live_form_cancel);
+
+        imageThumbnail = root.findViewById(R.id.go_live_form_thumbnail_preview);
+
+        createModeToggleGroup = root.findViewById(R.id.go_live_form_create_mode_toggle_group);
+        dateToggleGroup = root.findViewById(R.id.go_live_form_date_toggle_group);
+
+        buttonReleaseTimeDefault = root.findViewById(R.id.go_live_form_release_time_default);
+        buttonCreate = root.findViewById(R.id.go_live_form_create_button);
+
+        buttonReloadReplays = root.findViewById(R.id.go_live_form_replays_reload);
+
+        noTagsView = root.findViewById(R.id.form_no_added_tags);
+        noTagResultsView = root.findViewById(R.id.form_no_tag_results);
+        mediaContainer = root.findViewById(R.id.go_live_form_media_container);
+        progressThumbnailUploading = root.findViewById(R.id.go_live_form_thumbnail_upload_progress);
+        progressLoadingChannels = root.findViewById(R.id.go_live_form_loading_channels);
+        progressLoadingReplays = root.findViewById(R.id.go_live_form_replays_progress);
+        progressCreating = root.findViewById(R.id.go_live_form_creating);
+        layoutLivestreamDate = root.findViewById(R.id.go_live_form_date_container);
+        layoutScheduledPicker = root.findViewById(R.id.go_live_form_scheduled_picker);
+        layoutLivestreamReplays = root.findViewById(R.id.go_live_form_replays_container);
+        layoutLivestreamReplaysList = root.findViewById(R.id.go_live_form_replays_list);
+        layoutExtraFields = root.findViewById(R.id.go_live_form_extra_options_container);
+        layoutOtherLicenseDescription = root.findViewById(R.id.go_live_form_license_other_layout);
+        inlineDepositBalanceContainer = root.findViewById(R.id.go_live_form_inline_balance_container);
+
+        channelSpinner = root.findViewById(R.id.go_live_form_channel_spinner);
+        languageSpinner = root.findViewById(R.id.go_live_form_language_spinner);
+        licenseSpinner = root.findViewById(R.id.go_live_form_license_spinner);
+
+        Context context = getContext();
+        FlexboxLayoutManager flm1 = new FlexboxLayoutManager(context);
+        FlexboxLayoutManager flm2 = new FlexboxLayoutManager(context);
+        RecyclerView addedTagsList = root.findViewById(R.id.form_added_tags);
+        addedTagsList.setLayoutManager(flm1);
+        suggestedTagsList = root.findViewById(R.id.form_suggested_tags);
+        suggestedTagsList.setLayoutManager(flm2);
+
+        addedTagsAdapter = new TagListAdapter(new ArrayList<>(), context);
+        addedTagsAdapter.setCustomizeMode(TagListAdapter.CUSTOMIZE_MODE_REMOVE);
+        addedTagsAdapter.setClickListener(this);
+        addedTagsList.setAdapter(addedTagsAdapter);
+
+        suggestedTagsAdapter = new TagListAdapter(new ArrayList<>(), context);
+        suggestedTagsAdapter.setCustomizeMode(TagListAdapter.CUSTOMIZE_MODE_ADD);
+        suggestedTagsAdapter.setClickListener(this);
+        suggestedTagsList.setAdapter(suggestedTagsAdapter);
+
+        replaysViewPager = root.findViewById(R.id.go_live_form_replays_pager);
+
+        replaysTabLayout = root.findViewById(R.id.go_live_form_replays_tab_layout);
+
+        initUi();
+
+        return root;
+    }
+
+    private void initUi() {
+        Context context = getContext();
+
+        inputAddress.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                String value = Helper.getValue(charSequence);
+                boolean invalid = !Helper.isNullOrEmpty(value) && !LbryUri.isNameValid(value);
+                Helper.setViewVisibility(textInlineAddressInvalid, invalid ? View.VISIBLE : View.GONE);
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+
+            }
+        });
+
+        buttonReloadReplays.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                replaysViewPager.setAdapter(null);
+                fetchLivestreamReplays();
+            }
+        });
+
+        inputTagFilter.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                String value = Helper.getValue(charSequence);
+                setTagFilter(value);
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+
+            }
+        });
+
+        mediaContainer.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                checkStoragePermissionAndLaunchFilePicker();
+            }
+        });
+
+        channelSpinnerAdapter = new InlineChannelSpinnerAdapter(getContext(), R.layout.spinner_item_channel, new ArrayList<>());
+        channelSpinnerAdapter.addPlaceholder(false);
+
+        channelSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int position, long l) {
+                Object item = adapterView.getItemAtPosition(position);
+                if (item instanceof Claim) {
+                    Claim claim = (Claim) item;
+                    if (claim.isPlaceholder()) {
+                        if (!fetchingChannels) {
+                            showChannelCreator();
+                        }
+                        textAddressChannel.setText(R.string.url_anonymous_prefix);
+                    } else {
+                        textAddressChannel.setText(getString(R.string.url_channel_prefix, claim.getName()));
+                    }
+                    fetchLivestreamReplays();
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+
+            }
+        });
+
+        createModeToggleGroup.addOnButtonCheckedListener(new MaterialButtonToggleGroup.OnButtonCheckedListener() {
+            @Override
+            public void onButtonChecked(MaterialButtonToggleGroup group, int checkedId, boolean isChecked) {
+                modeLivestream = checkedId == R.id.go_live_form_new_livestream;
+                layoutLivestreamDate.setVisibility(modeLivestream ? View.VISIBLE : View.GONE);
+                layoutLivestreamReplays.setVisibility(modeLivestream ? View.GONE : View.VISIBLE);
+            }
+        });
+
+        dateToggleGroup.addOnButtonCheckedListener(new MaterialButtonToggleGroup.OnButtonCheckedListener() {
+            @Override
+            public void onButtonChecked(MaterialButtonToggleGroup group, int checkedId, boolean isChecked) {
+                anytimeStream = checkedId == R.id.go_live_form_anytime;
+                textDateInfo.setText(anytimeStream ? R.string.anytime_info : R.string.scheduled_info);
+                layoutScheduledPicker.setVisibility(anytimeStream ? View.GONE : View.VISIBLE);
+            }
+        });
+
+        linkShowExtraFields.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (layoutExtraFields.getVisibility() != View.VISIBLE) {
+                    layoutExtraFields.setVisibility(View.VISIBLE);
+                    linkShowExtraFields.setText(R.string.hide_extra_fields);
+                    scrollView.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            scrollView.fullScroll(ScrollView.FOCUS_DOWN);
+                        }
+                    });
+                } else {
+                    layoutExtraFields.setVisibility(View.GONE);
+                    linkShowExtraFields.setText(R.string.show_extra_fields);
+                }
+            }
+        });
+
+        setDefaultScheduled();
+
+        linkReleaseDate.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (context instanceof MainActivity) {
+                    MaterialDatePicker<Long> datePicker = MaterialDatePicker.Builder.datePicker()
+                            .setSelection(releaseDateMillis > Long.MIN_VALUE
+                                    ? releaseDateMillis : MaterialDatePicker.todayInUtcMilliseconds())
+                            .setCalendarConstraints(
+                                    new CalendarConstraints.Builder()
+                                            .setValidator(DateValidatorPointForward.now())
+                                            .build()
+                            )
+                            .build();
+                    datePicker.addOnPositiveButtonClickListener(new MaterialPickerOnPositiveButtonClickListener<Long>() {
+                        @Override
+                        public void onPositiveButtonClick(Long millis) {
+                            long localMillis = LocalDateTime
+                                    .ofInstant(Instant.ofEpochMilli(millis), UTC_ZONE)
+                                    .atZone(ZoneId.systemDefault())
+                                    .toInstant()
+                                    .toEpochMilli();
+                            linkReleaseDate.setText(DateUtils.formatDateTime(context, localMillis, DateUtils.FORMAT_SHOW_DATE));
+                            releaseDateMillis = millis;
+                            checkReleaseTimeInvalid();
+                        }
+                    });
+                    datePicker.show(((MainActivity) context).getSupportFragmentManager(), "DatePicker");
+                }
+            }
+        });
+
+        linkReleaseTime.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (context instanceof MainActivity) {
+                    Calendar calendar = Calendar.getInstance();
+                    calendar.set(Calendar.MINUTE, 0);
+                    calendar.add(Calendar.HOUR_OF_DAY, 1);
+
+                    MaterialTimePicker timePicker = new MaterialTimePicker.Builder()
+                            .setTimeFormat(DateFormat.is24HourFormat(context) ? TimeFormat.CLOCK_24H : TimeFormat.CLOCK_12H)
+                            .setHour(releaseTimeHours > -1 ? releaseTimeHours : calendar.get(Calendar.HOUR_OF_DAY))
+                            .setMinute(releaseTimeMinutes > -1 ? releaseTimeMinutes : calendar.get(Calendar.MINUTE))
+                            .build();
+                    timePicker.addOnPositiveButtonClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            releaseTimeHours = timePicker.getHour();
+                            releaseTimeMinutes = timePicker.getMinute();
+
+                            Calendar calendar = Calendar.getInstance();
+                            calendar.set(Calendar.HOUR_OF_DAY, releaseTimeHours);
+                            calendar.set(Calendar.MINUTE, releaseTimeMinutes);
+
+                            linkReleaseTime.setText(checkReleaseTimeInvalid() ? getString(R.string.time_default)
+                                    : DateUtils.formatDateTime(context, calendar.getTimeInMillis(), DateUtils.FORMAT_SHOW_TIME));
+                        }
+                    });
+                    timePicker.show(((MainActivity) context).getSupportFragmentManager(), "TimePicker");
+                }
+            }
+        });
+
+        buttonReleaseTimeDefault.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                setDefaultScheduled();
+                textReleaseTimePastNotAllowed.setVisibility(View.GONE);
+            }
+        });
+
+        languageSpinner.setAdapter(new LanguageSpinnerAdapter(context, R.layout.spinner_item_generic));
+        licenseSpinner.setAdapter(new LicenseSpinnerAdapter(context, R.layout.spinner_item_generic));
+
+        licenseSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int position, long l) {
+                License license = (License) adapterView.getAdapter().getItem(position);
+                boolean otherLicense = Arrays.asList(
+                        Predefined.LICENSE_COPYRIGHTED.toLowerCase(),
+                        Predefined.LICENSE_OTHER.toLowerCase()).contains(license.getName().toLowerCase());
+                Helper.setViewVisibility(layoutOtherLicenseDescription, otherLicense ? View.VISIBLE : View.GONE);
+                if (!otherLicense) {
+                    inputOtherLicenseDescription.setText(null);
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+
+            }
+        });
+
+        inputDeposit.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View view, boolean hasFocus) {
+                Helper.setViewVisibility(inlineDepositBalanceContainer, hasFocus ? View.VISIBLE : View.GONE);
+            }
+        });
+
+        linkCancel.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    ((MainActivity) context).onBackPressed();
+                }
+            }
+        });
+
+        buttonCreate.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (uploadingThumbnail) {
+                    showMessage(R.string.publish_thumbnail_in_progress);
+                    return;
+                } else if (Helper.isNullOrEmpty(uploadedThumbnailUrl)) {
+                    showError(getString(R.string.publish_no_thumbnail));
+                    return;
+                }
+
+                // check minimum deposit
+                String depositString = Helper.getValue(inputDeposit.getText());
+                double depositAmount;
+                try {
+                    depositAmount = Double.parseDouble(depositString);
+                } catch (NumberFormatException ex) {
+                    // pass
+                    showError(getString(R.string.please_enter_valid_deposit));
+                    return;
+                }
+                if (depositAmount < Helper.MIN_DEPOSIT) {
+                    showError(getResources().getQuantityString(R.plurals.min_deposit_required, depositAmount == 1 ? 1 : 2, String.valueOf(Helper.MIN_DEPOSIT)));
+                    return;
+                }
+                if (Lbry.getAvailableBalance() < depositAmount) {
+                    showError(getString(R.string.deposit_more_than_balance));
+                    return;
+                }
+
+                if (releaseDateMillis > Long.MIN_VALUE && (releaseTimeHours == -1 || releaseTimeMinutes == -1)) {
+                    showError(getString(R.string.invalid_release_time));
+                    return;
+                }
+
+                Claim claim = buildLivestreamClaim();
+                if (validateLivestreamClaim(claim)) {
+                    publishLivestream(claim);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        MainActivity activity = (MainActivity) getContext();
+        if (activity != null) {
+            activity.hideSearchBar();
+
+            activity.addFilePickerListener(this);
+            activity.addWalletBalanceListener(this);
+
+            activity.setActionBarTitle(R.string.go_live);
+        }
+    }
+
+    @Override
+    public void onStop() {
+        Context context = getContext();
+        if (context instanceof MainActivity) {
+            MainActivity activity = (MainActivity) getContext();
+            if (!MainActivity.startingFilePickerActivity) {
+                activity.removeWalletBalanceListener(this);
+                activity.removeFilePickerListener(this);
+            }
+        }
+
+        super.onStop();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        checkParams();
+        checkRewardsDriver();
+        updateFieldsFromCurrentClaim();
+        fetchChannels();
+
+        Context context = getContext();
+        if (context instanceof MainActivity) {
+            MainActivity activity = (MainActivity) context;
+            LbryAnalytics.setCurrentScreen(activity, "Go Live Form", "GoLiveForm");
+            activity.addStoragePermissionListener(this);
+            if (editMode) {
+                activity.setActionBarTitle(R.string.edit_livestream);
+                buttonCreate.setText(R.string.save);
+            }
+        }
+
+        String filterText = Helper.getValue(inputTagFilter.getText());
+        updateSuggestedTags(filterText, SUGGESTED_TAGS_LIMIT, true);
+    }
+
+    private void checkParams() {
+        Map<String, Object> params = getParams();
+        if (params != null) {
+            if (params.containsKey("claim")) {
+                Claim claim = (Claim) params.get("claim");
+                if (claim != null && !claim.equals(currentClaim)) {
+                    currentClaim = claim;
+                    editFieldsLoaded = false;
+                }
+            }
+        }
+    }
+
+    private void updateFieldsFromCurrentClaim() {
+        if (currentClaim != null && !editFieldsLoaded) {
+            Context context = getContext();
+            try {
+                Claim.StreamMetadata metadata = (Claim.StreamMetadata) currentClaim.getValue();
+                if (context != null) {
+                    uploadedThumbnailUrl = currentClaim.getThumbnailUrl(Utils.STREAM_THUMBNAIL_WIDTH, Utils.STREAM_THUMBNAIL_HEIGHT, Utils.STREAM_THUMBNAIL_Q);
+                }
+                if (context != null && !Helper.isNullOrEmpty(uploadedThumbnailUrl)) {
+                    Glide.with(context.getApplicationContext()).load(uploadedThumbnailUrl).centerCrop().into(imageThumbnail);
+                }
+
+                inputTitle.setText(currentClaim.getTitle());
+                inputDescription.setText(currentClaim.getDescription());
+                if (addedTagsAdapter != null && currentClaim.getTagObjects() != null) {
+                    addedTagsAdapter.addTags(currentClaim.getTagObjects());
+                    updateSuggestedTags(currentTagFilter, SUGGESTED_TAGS_LIMIT, true);
+                }
+
+                inputAddress.setText(currentClaim.getName());
+                inputDeposit.setText(currentClaim.getAmount());
+
+                if (metadata.getLanguages() != null && metadata.getLanguages().size() > 0) {
+                    // get the first language
+                    String langCode = metadata.getLanguages().get(0);
+                    int langCodePosition = ((LanguageSpinnerAdapter) languageSpinner.getAdapter()).getItemPosition(langCode);
+                    if (langCodePosition > -1) {
+                        languageSpinner.setSelection(langCodePosition);
+                    }
+                }
+
+                if (!Helper.isNullOrEmpty(metadata.getLicense())) {
+                    LicenseSpinnerAdapter adapter = (LicenseSpinnerAdapter) licenseSpinner.getAdapter();
+                    int licPosition = adapter.getItemPosition(metadata.getLicense());
+                    if (licPosition == -1) {
+                        licPosition = adapter.getItemPosition(Predefined.LICENSE_OTHER);
+                    }
+                    if (licPosition > -1) {
+                        licenseSpinner.setSelection(licPosition);
+                    }
+
+                    License selectedLicense = (License) licenseSpinner.getSelectedItem();
+                    boolean otherLicense = Arrays.asList(
+                            Predefined.LICENSE_COPYRIGHTED.toLowerCase(),
+                            Predefined.LICENSE_OTHER.toLowerCase()).contains(selectedLicense.getName().toLowerCase());
+                    inputOtherLicenseDescription.setText(otherLicense ? metadata.getLicense() : null);
+                }
+
+                inputAddress.setEnabled(false);
+                editMode = true;
+                editFieldsLoaded = true;
+            } catch (ClassCastException ex) {
+                // invalid claim value type
+                cancelOnFatalCondition(getString(R.string.publish_invalid_claim_type));
+            }
+        }
+    }
+
+    // region: Channels
+    private void fetchChannels() {
+        if (Lbry.ownChannels != null && Lbry.ownChannels.size() > 0) {
+            updateChannelList(Lbry.ownChannels);
+            return;
+        }
+
+        fetchingChannels = true;
+        disableChannelSpinner();
+        Map<String, Object> options = Lbry.buildClaimListOptions(Claim.TYPE_CHANNEL, 1, 999, true);
+        ClaimListTask task = new ClaimListTask(options, progressLoadingChannels, new ClaimListResultHandler() {
+            @Override
+            public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
+                Lbry.ownChannels = new ArrayList<>(claims);
+                updateChannelList(Lbry.ownChannels);
+                enableChannelSpinner();
+                fetchingChannels = false;
+            }
+
+            @Override
+            public void onError(Exception error) {
+                enableChannelSpinner();
+                fetchingChannels = false;
+            }
+        });
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    private void disableChannelSpinner() {
+        Helper.setViewEnabled(channelSpinner, false);
+    }
+
+    private void enableChannelSpinner() {
+        Helper.setViewEnabled(channelSpinner, true);
+        if (channelSpinner != null) {
+            Claim selectedClaim = (Claim) channelSpinner.getSelectedItem();
+            if (selectedClaim != null) {
+                if (selectedClaim.isPlaceholder()) {
+                    showChannelCreator();
+                }
+            }
+        }
+    }
+
+    private void showChannelCreator() {
+        MainActivity activity = (MainActivity) getActivity();
+
+        if (activity != null) {
+            activity.showChannelCreator(this);
+        }
+    }
+
+    private void updateChannelList(List<Claim> channels) {
+        Context context = getContext();
+        if (channelSpinnerAdapter == null) {
+            if (context != null) {
+                channelSpinnerAdapter = new InlineChannelSpinnerAdapter(context, R.layout.spinner_item_channel, new ArrayList<>(channels));
+                channelSpinnerAdapter.addPlaceholder(false);
+                channelSpinnerAdapter.notifyDataSetChanged();
+            }
+        } else {
+            channelSpinnerAdapter.clear();
+            channelSpinnerAdapter.addPlaceholder(false);
+            channelSpinnerAdapter.addAll(channels);
+            channelSpinnerAdapter.notifyDataSetChanged();
+        }
+
+        if (channelSpinner != null) {
+            channelSpinner.setAdapter(channelSpinnerAdapter);
+        }
+
+        if (channelSpinnerAdapter != null && channelSpinner != null) {
+            if (editMode) {
+                if (currentClaim.getSigningChannel() != null && !editChannelSpinnerLoaded) {
+                    int position = channelSpinnerAdapter.getItemPosition(currentClaim.getSigningChannel());
+                    if (position > -1) {
+                        channelSpinner.setSelection(position);
+                    }
+                    editChannelSpinnerLoaded = true;
+                }
+            } else {
+                if (channelSpinnerAdapter.getCount() > 1) {
+                    String defaultChannelName = Helper.getDefaultChannelName(context);
+
+                    List<Claim> defaultChannel = channels.stream().filter(c -> c != null && c.getName().equalsIgnoreCase(defaultChannelName)).collect(Collectors.toList());
+
+                    if (defaultChannel.size() > 0) {
+                        channelSpinner.setSelection(channelSpinnerAdapter.getItemPosition(defaultChannel.get(0)));
+                    } else {
+                        // Always select something as livestreaming needs a channel
+                        channelSpinner.setSelection(1);
+                    }
+                }
+            }
+        }
+    }
+    // endregion
+
+    // region: Tags
+    private void setTagFilter(String filter) {
+        currentTagFilter = filter;
+        updateSuggestedTags(currentTagFilter, SUGGESTED_TAGS_LIMIT, true);
+    }
+
+    private void checkNoAddedTags() {
+        Helper.setViewVisibility(noTagsView, addedTagsAdapter == null || addedTagsAdapter.getItemCount() == 0 ? View.VISIBLE : View.GONE);
+    }
+
+    private void checkNoTagResults() {
+        Helper.setViewVisibility(noTagResultsView, suggestedTagsAdapter == null || suggestedTagsAdapter.getItemCount() == 0 ? View.VISIBLE : View.GONE);
+    }
+
+    private void addTag(Tag tag) {
+        if (saveInProgress) {
+            return;
+        }
+
+        if (addedTagsAdapter.getTags().contains(tag)) {
+            showMessage(getString(R.string.tag_already_added, tag.getName()));
+            return;
+        }
+        if (addedTagsAdapter.getItemCount() == 5) {
+            showMessage(R.string.tag_limit_reached);
+            return;
+        }
+
+        addedTagsAdapter.addTag(tag);
+        if (suggestedTagsAdapter != null) {
+            suggestedTagsAdapter.removeTag(tag);
+        }
+        updateSuggestedTags(currentTagFilter, SUGGESTED_TAGS_LIMIT, false);
+
+        checkNoAddedTags();
+        checkNoTagResults();
+    }
+
+    public void removeTag(Tag tag) {
+        if (saveInProgress) {
+            return;
+        }
+        addedTagsAdapter.removeTag(tag);
+        updateSuggestedTags(currentTagFilter, SUGGESTED_TAGS_LIMIT, false);
+        checkNoAddedTags();
+        checkNoTagResults();
+    }
+
+    private void updateSuggestedTags(String filter, int limit, boolean clearPrevious) {
+        UpdateSuggestedTagsTask task = new UpdateSuggestedTagsTask(
+                filter,
+                limit,
+                addedTagsAdapter,
+                suggestedTagsAdapter,
+                clearPrevious,
+                true, new UpdateSuggestedTagsTask.KnownTagsHandler() {
+            @Override
+            public void onSuccess(List<Tag> tags) {
+                if (suggestedTagsAdapter == null) {
+                    suggestedTagsAdapter = new TagListAdapter(tags, getContext());
+                    suggestedTagsAdapter.setCustomizeMode(TagListAdapter.CUSTOMIZE_MODE_ADD);
+                    suggestedTagsAdapter.setClickListener(GoLiveFormFragment.this);
+                    if (suggestedTagsList != null) {
+                        suggestedTagsList.setAdapter(suggestedTagsAdapter);
+                    }
+                } else {
+                    suggestedTagsAdapter.setTags(tags);
+                }
+
+                checkNoAddedTags();
+                checkNoTagResults();
+            }
+        });
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+    // endregion
+
+    // region: Replays
+    private void fetchLivestreamReplays() {
+        Claim channel = (Claim) channelSpinner.getSelectedItem();
+        if (channel.isPlaceholder()) {
+            layoutLivestreamReplaysList.setVisibility(View.GONE);
+            textReplaysTitle.setText(R.string.no_replays);
+            return;
+        }
+        LivestreamReplaysTask task = new LivestreamReplaysTask(channel, progressLoadingReplays, Lbryio.AUTH_TOKEN, new LivestreamReplaysResultHandler() {
+            @Override
+            public void onSuccess(List<LivestreamReplay> replays) {
+                if (replays.size() != 0) {
+                    layoutLivestreamReplaysList.setVisibility(View.VISIBLE);
+                    textReplaysTitle.setText(R.string.select_replay);
+                } else {
+                    layoutLivestreamReplaysList.setVisibility(View.GONE);
+                    textReplaysTitle.setText(R.string.no_replays);
+                    return;
+                }
+
+                replaysAdapter = new ReplaysPagerAdapter(getActivity(), replays, new ReplaysPagerAdapter.SelectedReplayManager() {
+                    @Override
+                    public LivestreamReplay getSelectedReplay() {
+                        return selectedLivestreamReplay;
+                    }
+
+                    @Override
+                    public void setSelectedReplay(LivestreamReplay replay) {
+                        selectedLivestreamReplay = replay;
+                    }
+                });
+                replaysViewPager.setAdapter(replaysAdapter);
+                new TabLayoutMediator(replaysTabLayout, replaysViewPager, new TabLayoutMediator.TabConfigurationStrategy() {
+                    @Override
+                    public void onConfigureTab(@NonNull TabLayout.Tab tab, int position) {
+                        tab.setText(String.valueOf(position + 1));
+                    }
+                }).attach();
+            }
+
+            @Override
+            public void onError(Exception error) {
+                showError(error.getMessage());
+            }
+        });
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+    // endregion
+
+    // region: Claim creation and publish
+    private Claim buildLivestreamClaim() {
+        Claim claim = new Claim();
+
+        claim.setName(Helper.getValue(inputAddress.getText()));
+        claim.setAmount(Helper.getValue(inputDeposit.getText()));
+
+        Claim.StreamMetadata metadata = new Claim.StreamMetadata();
+        metadata.setTitle(Helper.getValue(inputTitle.getText()));
+        metadata.setDescription(Helper.getValue(inputDescription.getText()));
+
+        List<String> tags = Helper.getTagsForTagObjects(addedTagsAdapter.getTags());
+        if (!anytimeStream) {
+            tags.add(SCHEDULED_LIVESTREAM_TAG);
+        }
+        metadata.setTags(tags);
+
+        Claim selectedChannel = (Claim) channelSpinner.getSelectedItem();
+        if (selectedChannel != null && !selectedChannel.isPlaceholder() && !selectedChannel.isPlaceholderAnonymous()) {
+            claim.setSigningChannel(selectedChannel);
+        }
+
+        if (!Helper.isNullOrEmpty(uploadedThumbnailUrl)) {
+            Claim.Resource thumbnail = new Claim.Resource();
+            thumbnail.setUrl(uploadedThumbnailUrl);
+            metadata.setThumbnail(thumbnail);
+        }
+
+        Language selectedLanguage = (Language) languageSpinner.getSelectedItem();
+        if (selectedLanguage != null) {
+            metadata.setLanguages(Collections.singletonList(selectedLanguage.getCode()));
+        }
+
+        License selectedLicense = (License) licenseSpinner.getSelectedItem();
+        if (selectedLicense != null) {
+            boolean otherLicense = Arrays.asList(
+                    Predefined.LICENSE_COPYRIGHTED.toLowerCase(),
+                    Predefined.LICENSE_OTHER.toLowerCase()).contains(selectedLicense.getName().toLowerCase());
+            metadata.setLicense(otherLicense ? Helper.getValue(inputOtherLicenseDescription.getText()) : selectedLicense.getName());
+            metadata.setLicenseUrl(selectedLicense.getUrl());
+        }
+
+        if (!anytimeStream &&
+                releaseDateMillis > Long.MIN_VALUE &&
+                releaseTimeHours > -1 &&
+                releaseTimeMinutes > -1) {
+            long secs = LocalDateTime
+                    .ofInstant(Instant.ofEpochMilli(releaseDateMillis), UTC_ZONE)
+                    .plusHours(releaseTimeHours)
+                    .plusMinutes(releaseTimeMinutes)
+                    .atZone(ZoneId.systemDefault())
+                    .toEpochSecond();
+            metadata.setReleaseTime(secs);
+        }
+
+        claim.setValueType(Claim.TYPE_STREAM);
+        claim.setValue(metadata);
+
+        return claim;
+    }
+
+    private boolean validateLivestreamClaim(Claim claim) {
+        if (Helper.isNullOrEmpty(claim.getTitle())) {
+            showError(getString(R.string.please_provide_title));
+            return false;
+        }
+        if (Helper.isNullOrEmpty(claim.getName())) {
+            showError(getString(R.string.please_specify_address));
+            return false;
+        }
+        if (!LbryUri.isNameValid(claim.getName())) {
+            showError(getString(R.string.address_invalid_characters));
+            return false;
+        }
+        if (claim.getSigningChannel() == null
+                || claim.getSigningChannel().isPlaceholder()
+                || claim.getSigningChannel().isPlaceholderAnonymous()) {
+            showError(getString(R.string.livestream_select_channel));
+            return false;
+        }
+        if (!editMode && Helper.claimNameExists(claim.getName())) {
+            showError(getString(R.string.address_already_used));
+            return false;
+        }
+
+        return true;
+    }
+
+    private void publishLivestream(Claim claim) {
+        saveInProgress = true;
+        ClaimResultHandler handler = new ClaimResultHandler() {
+            @Override
+            public void beforeStart() {
+                preSave();
+            }
+
+            @Override
+            public void onSuccess(Claim claimResult) {
+                postSave();
+                showMessage(modeLivestream ? R.string.livestream_pending
+                        : (editMode ? R.string.update_successful : R.string.publish_successful));
+
+                // Run the logPublish task
+                if (!BuildConfig.DEBUG) {
+                    claimResult.setSigningChannel(claim.getSigningChannel());
+                    LogPublishTask logPublish = new LogPublishTask(claimResult);
+                    logPublish.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                }
+
+                // publish done
+                Bundle bundle = new Bundle();
+                bundle.putString("claim_id", claimResult.getClaimId());
+                bundle.putString("claim_name", claimResult.getName());
+                LbryAnalytics.logEvent(editMode ? LbryAnalytics.EVENT_PUBLISH_UPDATE : LbryAnalytics.EVENT_PUBLISH, bundle);
+
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    MainActivity activity = (MainActivity) context;
+                    activity.sendBroadcast(new Intent(modeLivestream
+                            ? MainActivity.ACTION_LIVESTREAM_PUBLISH_SUCCESSFUL : MainActivity.ACTION_PUBLISH_SUCCESSFUL));
+                }
+            }
+
+            @Override
+            public void onError(Exception error) {
+                showError(error.getMessage());
+                postSave();
+            }
+        };
+        if (modeLivestream) {
+            PublishClaimTask task = new PublishClaimTask(claim, null, Lbryio.AUTH_TOKEN, handler);
+            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        } else {
+            String url = selectedLivestreamReplay != null ? selectedLivestreamReplay.getUrl() : null;
+            ReplayPublishTask task = new ReplayPublishTask(claim, url, null, Lbryio.AUTH_TOKEN, handler);
+            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        }
+    }
+
+    private void preSave() {
+        saveInProgress = true;
+
+        Helper.setViewVisibility(progressCreating, View.VISIBLE);
+
+        // disable input views
+        Helper.setViewEnabled(inputTitle, false);
+        Helper.setViewEnabled(inputAddress, false);
+        Helper.setViewEnabled(inputDescription, false);
+        Helper.setViewEnabled(inputTagFilter, false);
+        Helper.setViewEnabled(inputOtherLicenseDescription, false);
+        Helper.setViewEnabled(inputDeposit, false);
+
+        Helper.setViewEnabled(channelSpinner, false);
+        Helper.setViewEnabled(languageSpinner, false);
+        Helper.setViewEnabled(licenseSpinner, false);
+
+        Helper.setViewEnabled(linkShowExtraFields, false);
+        Helper.setViewEnabled(linkCancel, false);
+        Helper.setViewEnabled(buttonCreate,  false);
+    }
+
+    private void postSave() {
+        Helper.setViewEnabled(inputTitle, true);
+        Helper.setViewEnabled(inputAddress, true);
+        Helper.setViewEnabled(inputDescription, true);
+        Helper.setViewEnabled(inputTagFilter, true);
+        Helper.setViewEnabled(inputOtherLicenseDescription, true);
+        Helper.setViewEnabled(inputDeposit, true);
+
+        Helper.setViewEnabled(channelSpinner, true);
+        Helper.setViewEnabled(languageSpinner, true);
+        Helper.setViewEnabled(licenseSpinner, true);
+
+        Helper.setViewEnabled(linkShowExtraFields, true);
+        Helper.setViewEnabled(linkCancel, true);
+        Helper.setViewEnabled(buttonCreate,  true);
+
+        Helper.setViewVisibility(progressCreating, View.GONE);
+
+        saveInProgress = false;
+    }
+    // endregion
+
+    private void checkStoragePermissionAndLaunchFilePicker() {
+        Context context = getContext();
+        if (MainActivity.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, context)) {
+            launchPickerPending = false;
+            launchFilePicker();
+        } else {
+            launchPickerPending = true;
+            MainActivity.requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    MainActivity.REQUEST_STORAGE_PERMISSION,
+                    getString(R.string.storage_permission_rationale_images),
+                    context,
+                    true);
+        }
+    }
+
+    private void launchFilePicker() {
+        Context context = getContext();
+        if (context instanceof MainActivity) {
+            MainActivity.startingFilePickerActivity = true;
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.setType("image/*");
+            ((MainActivity) context).startActivityForResult(
+                    Intent.createChooser(intent, getString(R.string.select_thumbnail)),
+                    MainActivity.REQUEST_FILE_PICKER);
+        }
+    }
+
+    private void uploadThumbnail(String thumbnailPath) {
+        if (uploadingThumbnail) {
+            View view = getView();
+            if (view != null) {
+                showMessage(R.string.wait_for_upload);
+            }
+            return;
+        }
+
+        Context context = getContext();
+        if (context != null) {
+            Glide.with(context.getApplicationContext()).load(thumbnailPath).centerCrop().into(imageThumbnail);
+        }
+
+        uploadingThumbnail = true;
+        uploadedThumbnailUrl = null;
+        UploadImageTask task = new UploadImageTask(thumbnailPath, progressThumbnailUploading, new UploadImageTask.UploadThumbnailHandler() {
+            @Override
+            public void onSuccess(String url) {
+                lastSelectedThumbnailFile = thumbnailPath;
+                uploadedThumbnailUrl = url;
+                uploadingThumbnail = false;
+            }
+
+            @Override
+            public void onError(Exception error) {
+                View view = getView();
+                if (context != null && view != null) {
+                    showError(getString(R.string.image_upload_failed));
+                }
+                lastSelectedThumbnailFile = null;
+                imageThumbnail.setImageDrawable(null);
+                uploadingThumbnail = false;
+            }
+        });
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    private void cancelOnFatalCondition(String message) {
+        Context context = getContext();
+        if (context instanceof MainActivity) {
+            showError(message);
+            MainActivity activity = (MainActivity) context;
+            new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    activity.onBackPressed();
+                }
+            }, 100);
+        }
+    }
+
+    private void checkRewardsDriver() {
+        Context ctx = getContext();
+        if (ctx != null) {
+            String rewardsDriverText = String.format("%s\n%s",
+                    getString(R.string.livestreaming_requires_credits), getString(R.string.tap_here_to_get_some));
+            checkRewardsDriverCard(rewardsDriverText, Helper.MIN_DEPOSIT);
+        }
+    }
+
+    private void setDefaultScheduled() {
+        releaseDateMillis = MaterialDatePicker.todayInUtcMilliseconds();
+
+        Context context = getContext();
+        if (context != null) {
+            linkReleaseDate.setText(DateUtils.formatDateTime(
+                    context, releaseDateMillis, DateUtils.FORMAT_SHOW_DATE));
+        }
+
+        setDefaultScheduledTime();
+    }
+
+    private void setDefaultScheduledTime() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.add(Calendar.HOUR_OF_DAY, 1);
+
+        releaseTimeHours = calendar.get(Calendar.HOUR_OF_DAY);
+        releaseTimeMinutes = calendar.get(Calendar.MINUTE);
+
+        Context context = getContext();
+        if (context != null) {
+            linkReleaseTime.setText(DateUtils.formatDateTime(
+                    context, calendar.getTimeInMillis(), DateUtils.FORMAT_SHOW_TIME));
+        }
+    }
+
+    private boolean checkReleaseTimeInvalid() {
+        boolean isReleaseTimeInvalid = releaseTimeHours > -1 && releaseTimeMinutes > -1
+                && LocalDateTime
+                        .ofInstant(Instant.ofEpochMilli(releaseDateMillis), UTC_ZONE)
+                        .plusHours(releaseTimeHours)
+                        .plusMinutes(releaseTimeMinutes)
+                        .isBefore(LocalDateTime.now().minusMinutes(1));
+        textReleaseTimePastNotAllowed.setVisibility(isReleaseTimeInvalid ? View.VISIBLE : View.GONE);
+        if (isReleaseTimeInvalid) {
+            releaseTimeHours = -1;
+            releaseTimeMinutes = -1;
+        }
+        return isReleaseTimeInvalid;
+    }
+
+    // region: Callbacks
+    @Override
+    public void onFilePicked(String filePath) {
+        if (Helper.isNullOrEmpty(filePath)) {
+            View view = getView();
+            if (view != null) {
+                showError(getString(R.string.undetermined_image_filepath));
+            }
+            return;
+        }
+
+        Context context = getContext();
+        if (context != null) {
+            if (filePath.equalsIgnoreCase(lastSelectedThumbnailFile)) {
+                // previous selected cover was uploaded successfully
+                return;
+            }
+
+            Uri fileUri = Uri.fromFile(new File(filePath));
+            Glide.with(context.getApplicationContext()).load(fileUri).centerCrop().into(imageThumbnail);
+            uploadThumbnail(filePath);
+        }
+    }
+
+    @Override
+    public void onFilePickerCancelled() {
+        // nothing to do here
+        // At some point in the future, allow file picking for publish file?
+    }
+
+    @Override
+    public void onStoragePermissionGranted() {
+        if (launchPickerPending) {
+            launchPickerPending = false;
+            launchFilePicker();
+        }
+    }
+
+    @Override
+    public void onStoragePermissionRefused() {
+        if (!storageRefusedOnce) {
+            try {
+                showError(getString(R.string.storage_permission_rationale_images));
+            } catch (IllegalStateException ex) {
+                // pass
+            }
+            storageRefusedOnce = true;
+        }
+        launchPickerPending = false;
+    }
+
+    @Override
+    public void onTagClicked(Tag tag, int customizeMode) {
+        if (customizeMode == TagListAdapter.CUSTOMIZE_MODE_ADD) {
+            addTag(tag);
+        } else if (customizeMode == TagListAdapter.CUSTOMIZE_MODE_REMOVE) {
+            removeTag(tag);
+        }
+    }
+
+    @Override
+    public void onWalletBalanceUpdated(WalletBalance walletBalance) {
+        if (walletBalance != null && textInlineDepositBalance != null) {
+            textInlineDepositBalance.setText(Helper.shortCurrencyFormat(walletBalance.getAvailable().doubleValue()));
+        }
+        checkRewardsDriver();
+    }
+
+    @Override
+    public void onChannelCreated(Claim claimResult) {
+        // add the claim to the channel list and set it as the selected item
+        if (channelSpinnerAdapter != null) {
+            channelSpinnerAdapter.add(claimResult);
+        } else {
+            updateChannelList(Collections.singletonList(claimResult));
+        }
+        if (channelSpinner != null && channelSpinnerAdapter != null) {
+            // Ensure adapter is set for the spinner
+            if (channelSpinner.getAdapter() == null) {
+                channelSpinner.setAdapter(channelSpinnerAdapter);
+            }
+            channelSpinner.setSelection(channelSpinnerAdapter.getCount() - 1);
+        }
+    }
+    // endregion
+}

--- a/app/src/main/java/com/odysee/app/ui/publish/LivestreamsFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/LivestreamsFragment.java
@@ -1,0 +1,530 @@
+package com.odysee.app.ui.publish;
+
+import android.app.Activity;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.PersistableBundle;
+import android.text.Html;
+import android.text.method.PasswordTransformationMethod;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.view.ActionMode;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.textfield.TextInputEditText;
+import com.odysee.app.GoLiveActivity;
+import com.odysee.app.MainActivity;
+import com.odysee.app.OdyseeApp;
+import com.odysee.app.R;
+import com.odysee.app.adapter.ClaimListAdapter;
+import com.odysee.app.exceptions.ApiCallException;
+import com.odysee.app.listener.SelectionModeListener;
+import com.odysee.app.model.Claim;
+import com.odysee.app.tasks.claim.AbandonHandler;
+import com.odysee.app.tasks.claim.AbandonStreamTask;
+import com.odysee.app.tasks.claim.ClaimListResultHandler;
+import com.odysee.app.tasks.claim.ClaimListTask;
+import com.odysee.app.ui.BaseFragment;
+import com.odysee.app.utils.Helper;
+import com.odysee.app.utils.Lbry;
+import com.odysee.app.utils.LbryAnalytics;
+import com.odysee.app.utils.Lbryio;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class LivestreamsFragment extends BaseFragment implements ActionMode.Callback, SelectionModeListener {
+    private TextInputEditText textServer;
+    private TextInputEditText textStreamingKey;
+    private TextView linkShowStreamingKey;
+    private MaterialButton buttonStartStreaming;
+    private ProgressBar loading;
+    private RecyclerView contentList;
+    private View emptyView;
+    private FloatingActionButton fabCreate;
+
+    private ClaimListAdapter adapter;
+
+    private ActionMode actionMode;
+
+    private boolean waitingForConfirmation = true;
+    private boolean waitForConfirmationScheduled;
+    private List<Claim> pendingClaims;
+
+    private String streamKey;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_livestreams, container, false);
+
+        contentList = root.findViewById(R.id.livestreams_list);
+        contentList.setLayoutManager(new LinearLayoutManager(getContext()));
+
+        textServer = root.findViewById(R.id.livestreams_server_edit_text);
+        textStreamingKey = root.findViewById(R.id.livestreams_key_edit_text);
+        linkShowStreamingKey = root.findViewById(R.id.livestreams_key_show_link);
+        buttonStartStreaming = root.findViewById(R.id.livestreams_start_streaming);
+        loading = root.findViewById(R.id.livestreams_list_loading);
+        emptyView = root.findViewById(R.id.livestreams_empty_container);
+        fabCreate = root.findViewById(R.id.livestreams_create_fab);
+
+        root.findViewById(R.id.livestreams_server_copy).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                copyEditText(textServer, false, R.string.stream_server_copied);
+            }
+        });
+
+        root.findViewById(R.id.livestreams_key_copy).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                copyEditText(textStreamingKey, true, R.string.stream_key_copied);
+            }
+        });
+
+        linkShowStreamingKey.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (linkShowStreamingKey.getText() == getString(R.string.show)) {
+                    linkShowStreamingKey.setText(R.string.hide);
+                    textStreamingKey.setTransformationMethod(null);
+                } else {
+                    linkShowStreamingKey.setText(R.string.show);
+                    textStreamingKey.setTransformationMethod(PasswordTransformationMethod.getInstance());
+                }
+            }
+        });
+
+        buttonStartStreaming.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                MainActivity activity = (MainActivity) getContext();
+                if (activity != null) {
+                    activity.onBackPressed();
+                }
+
+                Intent intent = new Intent(getContext(), GoLiveActivity.class);
+                intent.putExtra("streamKey", streamKey);
+                startActivity(intent);
+            }
+        });
+
+        View.OnClickListener createClickListener = new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    ((MainActivity) context).openFragment(GoLiveFormFragment.class, true, null);
+                }
+            }
+        };
+        root.findViewById(R.id.livestreams_create_button).setOnClickListener(createClickListener);
+        fabCreate.setOnClickListener(createClickListener);
+
+        return root;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        MainActivity activity = (MainActivity) getContext();
+        if (activity != null) {
+            LbryAnalytics.setCurrentScreen(activity, "Livestreams", "Livestreams");
+        }
+        if (adapter != null && contentList != null) {
+            contentList.setAdapter(adapter);
+        }
+        fetchChannels();
+    }
+
+    // region: Waiting for pending livestream claims
+    private void waitForPendingClaims() {
+        Activity a = getActivity();
+        if (a != null && !waitForConfirmationScheduled) {
+            ((OdyseeApp) a.getApplication()).getScheduledExecutor().scheduleAtFixedRate(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Map<String, Object> options = new HashMap<>(2);
+                        options.put("type", Claim.TYPE_STREAM);
+                        options.put("txid", pendingClaims.stream().map(Claim::getTxid).collect(Collectors.toList()));
+
+                        JSONObject result = (JSONObject) Lbry.authenticatedGenericApiCall(
+                                Lbry.METHOD_TXO_LIST, options, Lbryio.AUTH_TOKEN);
+                        JSONArray items = result.getJSONArray("items");
+
+                        for (int i = 0; i < items.length(); i++) {
+                            JSONObject item = items.getJSONObject(i);
+
+                            int confirmations = item.getInt("confirmations");
+                            String claimId = item.getString("claim_id");
+
+                            if (confirmations > 0) {
+                                adapter.getItems().stream()
+                                        .filter(c -> c.getClaimId().equals(claimId))
+                                        .findFirst()
+                                        .ifPresent(claim -> new Handler(Looper.getMainLooper()).post(new Runnable() {
+                                            @Override
+                                            public void run() {
+                                                int position = adapter.getItems().indexOf(claim);
+                                                claim.setConfirmations(confirmations);
+                                                adapter.notifyItemChanged(position);
+
+                                                pendingClaims.remove(claim);
+                                                if (pendingClaims.size() == 0) {
+                                                    buttonStartStreaming.setEnabled(true);
+                                                }
+                                            }
+                                        }));
+                            }
+                        }
+                    } catch (ApiCallException | JSONException ex) {
+                        // Do nothing, will retry in 30s
+                        showError(ex.getMessage());
+                    }
+                }
+            }, 0, 30, TimeUnit.SECONDS);
+            waitForConfirmationScheduled = true;
+        }
+    }
+    // endregion
+
+    private void fetchChannels() {
+        if (Lbry.ownChannels != null && Lbry.ownChannels.size() > 0) {
+            selectChannel(Lbry.ownChannels);
+            return;
+        }
+
+        Map<String, Object> options = Lbry.buildClaimListOptions(Claim.TYPE_CHANNEL, 1, 999, true);
+        loading.setVisibility(View.VISIBLE);
+        ClaimListTask task = new ClaimListTask(options, null, new ClaimListResultHandler() {
+            @Override
+            public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
+                Lbry.ownChannels = claims;
+                selectChannel(Lbry.ownChannels);
+            }
+
+            @Override
+            public void onError(Exception error) {
+                error.printStackTrace();
+                checkNoLivestreams();
+            }
+        });
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    private void selectChannel(List<Claim> channels) {
+        String defaultChannelName = Helper.getDefaultChannelName(getContext());
+
+        List<Claim> defaultChannel = channels.stream().filter(c -> c != null
+                && c.getName().equalsIgnoreCase(defaultChannelName)).collect(Collectors.toList());
+
+        Claim channel;
+        if (defaultChannel.size() > 0) {
+            channel = defaultChannel.get(0);
+        } else {
+            channel = channels.get(0);
+        }
+
+        fetchLivestreams(channel);
+        generateStreamKey(channel);
+    }
+
+    private void checkNoLivestreams() {
+        Helper.setViewVisibility(emptyView, adapter == null || adapter.getItemCount() == 0 ? View.VISIBLE : View.GONE);
+    }
+
+    private void fetchLivestreams(Claim channel) {
+        Map<String, Object> options = Lbry.buildClaimListOptions(
+                Claim.TYPE_STREAM, 1, 20, true);
+        options.put("channel_id", channel.getClaimId());
+        options.put("has_no_source", true);
+
+        ClaimListTask task = new ClaimListTask(options, Lbryio.AUTH_TOKEN, loading, new ClaimListResultHandler() {
+            @Override
+            public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
+                List<Claim> livestreams = Helper.filterDeletedClaims(claims);
+                Collections.sort(livestreams, new Comparator<Claim>() {
+                    @Override
+                    public int compare(Claim a, Claim b) {
+                        if (a.getConfirmations() == 0) {
+                            return -1;
+                        } else if (b.getConfirmations() == 0) {
+                            return 1;
+                        } else {
+                            return Long.compare(b.getTimestamp(), a.getTimestamp());
+                        }
+                    }
+                });
+
+                pendingClaims = livestreams
+                        .stream()
+                        .filter(claim -> claim.getConfirmations() == 0)
+                        .collect(Collectors.toList());
+                if (pendingClaims.size() > 0) {
+                    waitForPendingClaims();
+                } else {
+                    waitingForConfirmation = false;
+                    buttonStartStreaming.setEnabled(true);
+                }
+
+                Context context = getContext();
+                if (context != null) {
+                    adapter = new ClaimListAdapter(livestreams, context);
+                    adapter.setCanEnterSelectionMode(true);
+                    adapter.setSelectionModeListener(LivestreamsFragment.this);
+                    adapter.setListener(new ClaimListAdapter.ClaimListItemListener() {
+                        @Override
+                        public void onClaimClicked(Claim claim, int position) {
+                            if (context instanceof MainActivity) {
+                                MainActivity activity = (MainActivity) context;
+                                if (claim.getName().startsWith("@")) {
+                                    activity.openChannelClaim(claim);
+                                } else {
+                                    activity.openFileClaim(claim);
+                                }
+                            }
+                        }
+                    });
+                    if (contentList != null) {
+                        contentList.setAdapter(adapter);
+                    }
+                }
+                loading.setVisibility(View.GONE);
+                checkNoLivestreams();
+            }
+
+            @Override
+            public void onError(Exception error) {
+                error.printStackTrace();
+                checkNoLivestreams();
+                loading.setVisibility(View.GONE);
+            }
+        });
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    private void generateStreamKey(Claim channel) {
+        Activity a = getActivity();
+        if (a != null) {
+            ((OdyseeApp) a.getApplication()).getExecutor().execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        String hexData = Helper.toHexString(channel.getName());
+                        Map<String, Object> options = new HashMap<>(2);
+                        options.put("channel_id", channel.getClaimId());
+                        options.put("hexdata", hexData);
+
+                        JSONObject result = (JSONObject) Lbry.authenticatedGenericApiCall(
+                                "channel_sign", options, Lbryio.AUTH_TOKEN);
+                        String signature = result.getString("signature");
+                        String signingTs = result.getString("signing_ts");
+
+                        if (!Helper.isNullOrEmpty(signature) && !Helper.isNullOrEmpty(signingTs)) {
+                            streamKey = channel.getClaimId()
+                                    + "?d=" + hexData
+                                    + "&s=" + signature
+                                    + "&t=" + signingTs;
+
+                            new Handler(Looper.getMainLooper()).post(new Runnable() {
+                                @Override
+                                public void run() {
+                                    textStreamingKey.setText(streamKey);
+                                    if (!waitingForConfirmation) {
+                                        buttonStartStreaming.setEnabled(true);
+                                    }
+                                }
+                            });
+                        } else {
+                            new Handler(Looper.getMainLooper()).post(() ->
+                                    showError(getString(R.string.stream_key_not_generated)));
+                        }
+                    } catch (ApiCallException | JSONException ex) {
+                        ex.printStackTrace();
+                        new Handler(Looper.getMainLooper()).post(() ->
+                                showError(getString(R.string.stream_key_not_generated)));
+                    }
+                }
+            });
+        }
+    }
+
+    private void copyEditText(EditText text, boolean sensitive, @StringRes int copiedMessageResourceId) {
+        Context context = getContext();
+        if (context != null) {
+            ClipboardManager clipboardManager = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+            ClipData clip = ClipData.newPlainText(text.getHint(), text.getText());
+            if (sensitive && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                PersistableBundle bundle = new PersistableBundle();
+                bundle.putBoolean("android.content.extra.IS_SENSITIVE", true);
+                clip.getDescription().setExtras(bundle);
+            }
+            clipboardManager.setPrimaryClip(clip);
+        }
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            showMessage(copiedMessageResourceId);
+        }
+    }
+
+    private void handleDeleteSelectedClaims(List<Claim> selectedClaims) {
+        List<String> claimIds = new ArrayList<>();
+
+        for (Claim claim : selectedClaims) {
+            claimIds.add(claim.getClaimId());
+        }
+
+        if (actionMode != null) {
+            actionMode.finish();
+        }
+
+        Helper.setViewVisibility(contentList, View.INVISIBLE);
+        Helper.setViewVisibility(fabCreate, View.INVISIBLE);
+        AbandonStreamTask task = new AbandonStreamTask(claimIds, loading, Lbryio.AUTH_TOKEN, new AbandonHandler() {
+            @Override
+            public void onComplete(List<String> successfulClaimIds, List<String> failedClaimIds, List<Exception> errors) {
+                View root = getView();
+                if (root != null) {
+                    if (failedClaimIds.size() > 0) {
+                        showError(getString(R.string.one_or_more_publishes_failed_abandon));
+                    } else if (successfulClaimIds.size() == claimIds.size()) {
+                        try {
+                            showMessage(getResources().getQuantityString(R.plurals.publishes_deleted, successfulClaimIds.size()));
+                        } catch (IllegalStateException ex) {
+                            // pass
+                        }
+                    }
+                }
+
+                Lbry.abandonedClaimIds.addAll(successfulClaimIds);
+                if (adapter != null) {
+                    adapter.setItems(Helper.filterDeletedClaims(adapter.getItems()));
+                }
+
+                Helper.setViewVisibility(contentList, View.VISIBLE);
+                Helper.setViewVisibility(fabCreate, View.VISIBLE);
+                checkNoLivestreams();
+            }
+        });
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    @Override
+    public void onEnterSelectionMode() {
+        Context context = getContext();
+        if (context instanceof MainActivity) {
+            MainActivity activity = (MainActivity) context;
+            activity.startSupportActionMode(this);
+        }
+    }
+
+    @Override
+    public void onExitSelectionMode() {
+        if (actionMode != null) {
+            actionMode.finish();
+        }
+    }
+
+    @Override
+    public void onItemSelectionToggled() {
+        if (actionMode != null) {
+            actionMode.setTitle(String.valueOf(adapter.getSelectedCount()));
+            actionMode.invalidate();
+        }
+    }
+
+    @Override
+    public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
+        this.actionMode = actionMode;
+        actionMode.getMenuInflater().inflate(R.menu.menu_claim_list, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onPrepareActionMode(ActionMode actionMode, Menu menu) {
+        int selectionCount = adapter != null ? adapter.getSelectedCount() : 0;
+        menu.findItem(R.id.action_edit).setVisible(selectionCount == 1 &&
+                adapter.getSelectedItems().get(0).getConfirmations() > 0 &&
+                Claim.TYPE_STREAM.equalsIgnoreCase(adapter.getSelectedItems().get(0).getValueType()));
+        return true;
+    }
+
+    @Override
+    public boolean onActionItemClicked(ActionMode actionMode, MenuItem menuItem) {
+        if (R.id.action_edit == menuItem.getItemId()) {
+            if (adapter != null && adapter.getSelectedCount() > 0) {
+                Claim claim = adapter.getSelectedItems().get(0);
+                // start go live form with the claim
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    MainActivity activity = (MainActivity) context;
+                    activity.openGoLiveForm(claim);
+                }
+
+                actionMode.finish();
+                return true;
+            }
+        }
+        if (R.id.action_delete == menuItem.getItemId()) {
+            Context context = getContext();
+            if (context != null && adapter != null && adapter.getSelectedCount() > 0) {
+                final List<Claim> selectedClaims = new ArrayList<>(adapter.getSelectedItems());
+                String message = getResources().getQuantityString(R.plurals.confirm_delete_publishes, selectedClaims.size());
+                AlertDialog.Builder builder = new AlertDialog.Builder(getContext()).
+                        setTitle(R.string.delete_selection).
+                        setMessage(Html.fromHtml(message))
+                        .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                handleDeleteSelectedClaims(selectedClaims);
+                            }
+                        }).setNegativeButton(R.string.no, null);
+                builder.show();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public void onDestroyActionMode(ActionMode actionMode) {
+        if (adapter != null) {
+            adapter.clearSelectedItems();
+            adapter.setInSelectionMode(false);
+            adapter.notifyDataSetChanged();
+        }
+        this.actionMode = null;
+    }
+}

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishesFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishesFragment.java
@@ -235,7 +235,11 @@ public class PublishesFragment extends BaseFragment implements ActionMode.Callba
                 // start channel editor with the claim
                 Context context = getContext();
                 if (context instanceof MainActivity) {
-                    ((MainActivity) context).openPublishForm(claim);
+                    if (claim.hasSource()) {
+                        ((MainActivity) context).openPublishForm(claim);
+                    } else {
+                        ((MainActivity) context).openGoLiveForm(claim);
+                    }
                 }
 
                 actionMode.finish();

--- a/app/src/main/java/com/odysee/app/ui/publish/ReplaysPageFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/ReplaysPageFragment.java
@@ -1,0 +1,111 @@
+package com.odysee.app.ui.publish;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.RadioButton;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import com.bumptech.glide.Glide;
+import com.odysee.app.R;
+import com.odysee.app.model.LivestreamReplay;
+import com.odysee.app.utils.FormatTime;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import lombok.Setter;
+
+public class ReplaysPageFragment extends Fragment {
+    @Setter
+    private List<LivestreamReplay> replays;
+    @Setter
+    private ReplaySelectedListener listener;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_replays_page, container, false);
+
+        View layout1 = root.findViewById(R.id.replays_page_first);
+        View layout2 = root.findViewById(R.id.replays_page_second);
+        View layout3 = root.findViewById(R.id.replays_page_third);
+        View layout4 = root.findViewById(R.id.replays_page_fourth);
+
+        ImageView thumbnail1 = layout1.findViewById(R.id.livestream_replay_thumbnail);
+        ImageView thumbnail2 = layout2.findViewById(R.id.livestream_replay_thumbnail);
+        ImageView thumbnail3 = layout3.findViewById(R.id.livestream_replay_thumbnail);
+        ImageView thumbnail4 = layout4.findViewById(R.id.livestream_replay_thumbnail);
+
+        TextView textDuration1 = layout1.findViewById(R.id.livestream_replay_duration);
+        TextView textDuration2 = layout2.findViewById(R.id.livestream_replay_duration);
+        TextView textDuration3 = layout3.findViewById(R.id.livestream_replay_duration);
+        TextView textDuration4 = layout4.findViewById(R.id.livestream_replay_duration);
+
+        TextView textUploaded1 = layout1.findViewById(R.id.livestream_replay_uploaded);
+        TextView textUploaded2 = layout2.findViewById(R.id.livestream_replay_uploaded);
+        TextView textUploaded3 = layout3.findViewById(R.id.livestream_replay_uploaded);
+        TextView textUploaded4 = layout4.findViewById(R.id.livestream_replay_uploaded);
+
+        Context context = getContext();
+        if (context != null) {
+            // TODO: This crashes when changing Light/Dark mode
+            initLayout(context, layout1, thumbnail1, textDuration1, textUploaded1, replays.get(0));
+            if (replays.size() >= 2) initLayout(context, layout2, thumbnail2, textDuration2, textUploaded2, replays.get(1));
+            if (replays.size() >= 3) initLayout(context, layout3, thumbnail3, textDuration3, textUploaded3, replays.get(2));
+            if (replays.size() == 4) initLayout(context, layout4, thumbnail4, textDuration4, textUploaded4, replays.get(3));
+        }
+
+        RadioButton radio1 = layout1.findViewById(R.id.livestream_replay_radio_button);
+        RadioButton radio2 = layout2.findViewById(R.id.livestream_replay_radio_button);
+        RadioButton radio3 = layout3.findViewById(R.id.livestream_replay_radio_button);
+        RadioButton radio4 = layout4.findViewById(R.id.livestream_replay_radio_button);
+
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                radio1.setChecked(replays.get(0).selected);
+                if (replays.size() >= 2) radio2.setChecked(replays.get(1).selected);
+                if (replays.size() >= 3) radio3.setChecked(replays.get(2).selected);
+                if (replays.size() == 4) radio4.setChecked(replays.get(3).selected);
+            }
+        });
+
+        return root;
+    }
+
+    private void initLayout(Context context,
+                            View layout,
+                            ImageView thumbnail,
+                            TextView textDuration,
+                            TextView textUploaded,
+                            LivestreamReplay replay) {
+        layout.setVisibility(View.VISIBLE);
+
+        if (replay.getStatus().equals("inprogress")) {
+            layout.findViewById(R.id.livestream_replay_radio_button).setEnabled(false);
+
+            textDuration.setText(getString(R.string.replay_processing, replay.getPercentComplete()));
+        } else {
+            layout.setOnClickListener(view -> listener.onReplaySelected(replay));
+
+            Glide.with(context).load(replay.getThumbnailUrls().get(0)).into(thumbnail);
+
+            int minutes = (int) TimeUnit.NANOSECONDS.toMinutes(replay.getDuration());
+            textDuration.setText(getResources().getQuantityString(R.plurals.minutes, minutes, minutes));
+        }
+
+        textUploaded.setText(FormatTime.fromEpochMillis(replay.getCreated().getTime()));
+    }
+
+    public interface ReplaySelectedListener {
+        void onReplaySelected(LivestreamReplay replay);
+    }
+}

--- a/app/src/main/res/drawable/ic_sync.xml
+++ b/app/src/main/res/drawable/ic_sync.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/white" android:pathData="M12,4L12,1L8,5l4,4L12,6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM12,18c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z"/>
+</vector>

--- a/app/src/main/res/layout/activity_go_live.xml
+++ b/app/src/main/res/layout/activity_go_live.xml
@@ -6,232 +6,34 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".GoLiveActivity">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/livestream_controls"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="invisible"
-        tools:visibility="visible">
-
-        <com.haishinkit.view.HkSurfaceView
-            android:id="@+id/livestream_controls_camera_view"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/livestream_controls_toggle_streaming_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="32dp"
-            android:layout_marginBottom="32dp"
-            android:text="@string/start_streaming"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <ImageButton
-            android:id="@+id/livestream_controls_switch_camera_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="32dp"
-            android:layout_marginBottom="8dp"
-            android:contentDescription="@string/switch_camera"
-            android:backgroundTint="@color/smallIconBackground"
-            android:src="@drawable/ic_switch_camera"
-            app:layout_constraintBottom_toTopOf="@+id/livestream_controls_toggle_streaming_button"
-            app:layout_constraintEnd_toEndOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/livestream_options"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="invisible"
-        tools:visibility="visible">
-
-        <TextView
-            android:id="@+id/livestream_options_select_channel_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:text="@string/select_channel"
-            android:textSize="14sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <androidx.appcompat.widget.AppCompatSpinner
-            android:id="@+id/livestream_options_select_channel_spinner"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/livestream_options_select_channel_text" />
-
-        <TextView
-            android:id="@+id/livestream_options_channel_error_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp"
-            android:visibility="gone"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/livestream_options_select_channel_spinner"
-            tools:text="@string/channel_error_pending"
-            tools:visibility="visible" />
-
-        <TextView
-            android:id="@+id/livestream_options_specify_title_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:text="@string/specify_title"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/livestream_options_channel_error_text" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/livestream_options_title_input_layout"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:hint="@string/title"
-            android:padding="16dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/livestream_options_specify_title_text">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/livestream_options_title_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/inter"
-                android:singleLine="true"
-                android:textSize="14sp" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <TextView
-            android:id="@+id/livestream_options_select_thumbnail_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="@string/please_select_thumbnail"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/livestream_options_title_input_layout" />
-
-        <ImageView
-            android:id="@+id/livestream_options_thumbnail_preview"
-            android:layout_width="0dp"
-            android:layout_height="240dp"
-            android:layout_marginTop="16dp"
-            android:background="@android:color/black"
-            android:clickable="true"
-            android:focusable="true"
-            android:foreground="?attr/selectableItemBackground"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/livestream_options_select_thumbnail_text" />
-
-        <LinearLayout
-            android:id="@+id/livestream_options_thumbnail_upload_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@color/channelCoverBackground"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingHorizontal="8dp"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="@+id/livestream_options_thumbnail_preview"
-            app:layout_constraintTop_toTopOf="@+id/livestream_options_thumbnail_preview">
-
-            <ProgressBar
-                android:layout_width="16sp"
-                android:layout_height="16sp" />
-
-            <TextView
-                style="@style/TextView_Light"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:text="@string/uploading_thumbnail"
-                android:textColor="@color/white" />
-        </LinearLayout>
-
-        <RelativeLayout
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginBottom="16dp"
-            android:background="@drawable/bg_small_icon"
-            app:layout_constraintBottom_toBottomOf="@+id/livestream_options_thumbnail_preview"
-            app:layout_constraintEnd_toEndOf="@+id/livestream_options_thumbnail_preview"
-            app:layout_constraintStart_toStartOf="@+id/livestream_options_thumbnail_preview">
-
-            <ImageView
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:layout_centerInParent="true"
-                android:src="@drawable/ic_edit"
-                app:tint="@color/white" />
-        </RelativeLayout>
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/livestream_options_continue_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:fontFamily="@font/inter"
-            android:text="@string/continue_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/livestream_options_thumbnail_preview" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/livestream_precheck"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_constraintBottom_toBottomOf="@+id/livestream_controls"
-        app:layout_constraintEnd_toEndOf="@+id/livestream_controls"
-        app:layout_constraintStart_toStartOf="@+id/livestream_controls"
-        app:layout_constraintTop_toTopOf="@+id/livestream_controls">
-
-        <ImageView
-            android:id="@+id/livestream_precheck_spaceman_image"
-            android:layout_width="240dp"
-            android:layout_height="240dp"
-            android:src="@drawable/spaceman_happy"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/livestream_precheck_status_text"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="32dp"
-            android:layout_marginTop="32dp"
-            android:layout_marginEnd="32dp"
-            android:gravity="center"
-            android:text="@string/precheck_please_wait"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/livestream_precheck_spaceman_image" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <ProgressBar
-        android:id="@+id/livestream_progress"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:visibility="gone"
+    <com.haishinkit.view.HkSurfaceView
+        android:id="@+id/livestream_controls_camera_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible" />
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/livestream_controls_toggle_streaming_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="32dp"
+        android:layout_marginBottom="32dp"
+        android:text="@string/start_streaming"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <ImageButton
+        android:id="@+id/livestream_controls_switch_camera_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="32dp"
+        android:layout_marginBottom="8dp"
+        android:contentDescription="@string/switch_camera"
+        android:backgroundTint="@color/smallIconBackground"
+        android:src="@drawable/ic_switch_camera"
+        app:layout_constraintBottom_toTopOf="@+id/livestream_controls_toggle_streaming_button"
+        app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/card_livestream_replay.xml
+++ b/app/src/main/res/layout/card_livestream_replay.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+    <RadioButton
+        android:id="@+id/livestream_replay_radio_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="false"
+        android:focusable="false" />
+
+    <ImageView
+        android:id="@+id/livestream_replay_thumbnail"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:paddingStart="16dp"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        tools:ignore="RtlSymmetry">
+        <TextView
+            android:id="@+id/livestream_replay_duration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/inter"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/livestream_replay_uploaded"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/inter"
+            android:textSize="16sp"
+            android:textColor="?android:attr/textColorSecondary" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_go_live_form.xml
+++ b/app/src/main/res/layout/fragment_go_live_form.xml
@@ -1,0 +1,639 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/pageBackground">
+    <ScrollView
+        android:id="@+id/go_live_form_scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="16dp"
+            android:orientation="vertical">
+            <include layout="@layout/card_reward_driver"
+                android:visibility="gone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/go_live_form_create_mode_toggle_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="16dp"
+                app:singleSelection="true"
+                app:selectionRequired="true"
+                app:checkedButton="@+id/go_live_form_new_livestream">
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/go_live_form_new_livestream"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/new_livestream"
+                    style="?attr/materialButtonOutlinedStyle" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/choose_replay"
+                    style="?attr/materialButtonOutlinedStyle" />
+            </com.google.android.material.button.MaterialButtonToggleGroup>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+                <!-- region: Title, URL, Description -->
+                <androidx.cardview.widget.CardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/title">
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/go_live_form_input_title"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                style="@style/TextView_Light"
+                                android:textSize="14sp" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            android:orientation="horizontal">
+                            <TextView
+                                android:id="@+id/go_live_form_address_channel"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:fontFamily="@font/inter"
+                                android:textSize="14sp"
+                                android:text="@string/url_anonymous_prefix" />
+
+                            <com.google.android.material.textfield.TextInputLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="4dp"
+                                android:hint="@string/url">
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/go_live_form_input_address"
+                                    style="@style/TextView_Light"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:textSize="14sp" />
+                            </com.google.android.material.textfield.TextInputLayout>
+                        </LinearLayout>
+
+                        <TextView
+                            android:id="@+id/go_live_form_inline_address_invalid"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp"
+                            style="@style/TextView_Light"
+                            android:text="@string/address_invalid_characters"
+                            android:textColor="@color/red"
+                            android:visibility="gone" />
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            android:hint="@string/description">
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/go_live_form_input_description"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                style="@style/TextView_Light"
+                                android:inputType="textMultiLine"
+                                android:singleLine="false"
+                                android:textSize="14sp" />
+                        </com.google.android.material.textfield.TextInputLayout>
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+                <!-- endregion -->
+
+                <!-- region: Date -->
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/go_live_form_date_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/inter"
+                            android:textSize="20sp"
+                            android:text="@string/date" />
+
+                        <com.google.android.material.button.MaterialButtonToggleGroup
+                            android:id="@+id/go_live_form_date_toggle_group"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:singleSelection="true"
+                            app:selectionRequired="true"
+                            app:checkedButton="@+id/go_live_form_anytime">
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/go_live_form_anytime"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/anytime"
+                                style="?attr/materialButtonOutlinedStyle" />
+
+                            <com.google.android.material.button.MaterialButton
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/scheduled_time"
+                                style="?attr/materialButtonOutlinedStyle" />
+                        </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                        <LinearLayout
+                            android:id="@+id/go_live_form_scheduled_picker"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingTop="8dp"
+                            android:orientation="vertical"
+                            android:visibility="gone">
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:orientation="horizontal">
+                                <TextView
+                                    android:id="@+id/go_live_form_release_date"
+                                    style="@style/TextView_Light"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:clickable="true"
+                                    android:focusable="true"
+                                    android:fontFamily="@font/inter"
+                                    android:text="@string/time_default"
+                                    android:textColor="@color/odyseePink"
+                                    android:textSize="14sp" />
+
+                                <TextView
+                                    android:id="@+id/go_live_form_release_time"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="8sp"
+                                    android:clickable="true"
+                                    android:focusable="true"
+                                    style="@style/TextView_Light"
+                                    android:fontFamily="@font/inter"
+                                    android:textColor="@color/odyseePink"
+                                    android:textSize="14sp"
+                                    android:text="@string/time_default" />
+                            </LinearLayout>
+
+                            <TextView
+                                android:id="@+id/go_live_form_release_time_past_not_allowed"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:visibility="gone"
+                                style="@style/TextView_Light"
+                                android:fontFamily="@font/inter"
+                                android:textSize="14sp"
+                                android:text="@string/past_not_allowed" />
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/go_live_form_release_time_default"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:minWidth="0dp"
+                                android:minHeight="0dp"
+                                android:fontFamily="@font/inter"
+                                android:text="@string/time_default" />
+                        </LinearLayout>
+
+                        <TextView
+                            android:id="@+id/go_live_form_date_info"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingTop="8dp"
+                            android:fontFamily="@font/inter"
+                            android:textSize="14sp"
+                            android:text="@string/anytime_info" />
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+                <!-- endregion -->
+
+                <!-- region: Replays -->
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/go_live_form_replays_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:visibility="gone">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+                            <TextView
+                                android:id="@+id/go_live_form_replays_title"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:fontFamily="@font/inter"
+                                android:textSize="20sp"
+                                android:text="@string/select_replay" />
+
+                            <androidx.legacy.widget.Space
+                                android:layout_width="0dp"
+                                android:layout_height="match_parent"
+                                android:layout_weight="1" />
+
+                            <ProgressBar
+                                android:id="@+id/go_live_form_replays_progress"
+                                android:layout_width="wrap_content"
+                                android:layout_height="match_parent" />
+
+                            <ImageButton
+                                android:id="@+id/go_live_form_replays_reload"
+                                android:layout_width="wrap_content"
+                                android:layout_height="match_parent"
+                                android:background="@android:color/transparent"
+                                android:src="@drawable/ic_sync" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:id="@+id/go_live_form_replays_list"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:visibility="gone">
+                            <androidx.viewpager2.widget.ViewPager2
+                                android:id="@+id/go_live_form_replays_pager"
+                                android:layout_width="match_parent"
+                                android:layout_height="500dp" />
+
+                            <com.google.android.material.tabs.TabLayout
+                                android:id="@+id/go_live_form_replays_tab_layout"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="8dp"
+                                app:tabMode="scrollable"
+                                app:tabMaxWidth="45sp" />
+                        </LinearLayout>
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+                <!-- endregion -->
+
+                <!-- region: Tags -->
+                <androidx.cardview.widget.CardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="8dp"
+                            android:fontFamily="@font/inter"
+                            android:textSize="20sp"
+                            android:text="@string/tags" />
+
+                        <include layout="@layout/container_inline_tag_form" />
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+                <!-- endregion -->
+
+                <!-- region: Thumbnail -->
+                <androidx.cardview.widget.CardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/inter"
+                            android:textSize="20sp"
+                            android:text="@string/thumbnail" />
+
+                        <RelativeLayout
+                            android:id="@+id/go_live_form_media_container"
+                            android:clickable="true"
+                            android:foreground="?attr/selectableItemBackground"
+                            android:layout_width="match_parent"
+                            android:layout_height="240dp"
+                            android:background="@android:color/black">
+                            <ImageView
+                                android:id="@+id/go_live_form_thumbnail_preview"
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent" />
+
+                            <LinearLayout
+                                android:id="@+id/go_live_form_thumbnail_upload_progress"
+                                android:background="@color/channelCoverBackground"
+                                android:layout_alignParentEnd="true"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="4dp"
+                                android:layout_marginTop="4dp"
+                                android:orientation="horizontal"
+                                android:paddingTop="2dp"
+                                android:paddingBottom="2dp"
+                                android:paddingStart="8dp"
+                                android:paddingEnd="8dp"
+                                android:visibility="gone">
+                                <ProgressBar
+                                    android:layout_width="16dp"
+                                    android:layout_height="16dp" />
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="4dp"
+                                    style="@style/TextView_Light"
+                                    android:text="@string/uploading_thumbnail"
+                                    android:textColor="@color/white" />
+                            </LinearLayout>
+
+                            <RelativeLayout
+                                android:background="@drawable/bg_small_icon"
+                                android:layout_width="24dp"
+                                android:layout_height="24dp"
+                                android:layout_marginStart="16dp"
+                                android:layout_marginBottom="16dp"
+                                android:layout_alignParentBottom="true"
+                                android:layout_centerHorizontal="true">
+                                <ImageView
+                                    android:layout_width="16dp"
+                                    android:layout_height="16dp"
+                                    android:layout_centerInParent="true"
+                                    android:src="@drawable/ic_edit"
+                                    app:tint="@color/white" />
+                            </RelativeLayout>
+                        </RelativeLayout>
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+                <!-- endregion -->
+
+                <!-- region: Channel -->
+                <androidx.cardview.widget.CardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+                        <RelativeLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:layout_marginBottom="8dp">
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_centerVertical="true"
+                                android:fontFamily="@font/inter"
+                                android:text="@string/channel"
+                                android:textSize="20sp" />
+
+                            <ProgressBar
+                                android:id="@+id/go_live_form_loading_channels"
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                android:layout_alignParentEnd="true"
+                                android:layout_centerVertical="true"
+                                android:visibility="gone" />
+                        </RelativeLayout>
+
+                        <androidx.appcompat.widget.AppCompatSpinner
+                            android:id="@+id/go_live_form_channel_spinner"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp" />
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+                <!-- endregion -->
+
+                <!-- region: Additional Options -->
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/go_live_form_extra_options_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:visibility="gone">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="8dp"
+                            android:fontFamily="@font/inter"
+                            android:textSize="20sp"
+                            android:text="@string/additional_options" />
+
+                        <!-- region: Additional Options - Language -->
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            style="@style/TextView_Light"
+                            android:text="@string/language"
+                            android:textSize="14sp" />
+
+                        <androidx.appcompat.widget.AppCompatSpinner
+                            android:id="@+id/go_live_form_language_spinner"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp" />
+                        <!-- endregion -->
+
+                        <!-- region: Additional Options - License -->
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            style="@style/TextView_Light"
+                            android:text="@string/license"
+                            android:textSize="14sp" />
+
+                        <androidx.appcompat.widget.AppCompatSpinner
+                            android:id="@+id/go_live_form_license_spinner"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp" />
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/go_live_form_license_other_layout"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            android:hint="@string/license_desc"
+                            android:visibility="gone">
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/go_live_form_input_license_other"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                style="@style/TextView_Light"
+                                android:inputType="textNoSuggestions"
+                                android:textSize="14sp" />
+                        </com.google.android.material.textfield.TextInputLayout>
+                        <!-- endregion -->
+
+                        <!-- region: Additional Options - Deposit -->
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            style="@style/TextView_Light"
+                            android:text="@string/deposit"
+                            android:textSize="14sp" />
+
+                        <RelativeLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp">
+                            <com.google.android.material.textfield.TextInputLayout
+                                android:id="@+id/go_live_form_input_layout_deposit"
+                                android:layout_width="100dp"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/deposit">
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/go_live_form_input_deposit"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:fontFamily="@font/inter"
+                                    android:inputType="numberDecimal"
+                                    android:singleLine="true"
+                                    android:text="@string/min_deposit"
+                                    android:textSize="14sp" />
+                            </com.google.android.material.textfield.TextInputLayout>
+
+                            <TextView
+                                android:id="@+id/go_live_form_input_currency"
+                                style="@style/TextView_Light"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="8dp"
+                                android:layout_marginTop="30dp"
+                                android:layout_toEndOf="@id/go_live_form_input_layout_deposit"
+                                android:text="@string/lbc"
+                                android:textAllCaps="true"
+                                android:textSize="11sp" />
+
+                            <LinearLayout
+                                android:id="@+id/go_live_form_inline_balance_container"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="24dp"
+                                android:layout_marginTop="28dp"
+                                android:layout_toEndOf="@id/go_live_form_input_currency"
+                                android:orientation="horizontal"
+                                android:visibility="invisible">
+                                <ImageView
+                                    android:layout_width="12dp"
+                                    android:layout_height="12dp"
+                                    android:layout_gravity="center_vertical"
+                                    android:src="@drawable/ic_credits" />
+
+                                <TextView
+                                    android:id="@+id/go_live_form_inline_balance_value"
+                                    style="@style/TextView_Light"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="2dp" />
+                            </LinearLayout>
+                        </RelativeLayout>
+
+                        <TextView
+                            style="@style/TextView_Light"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp"
+                            android:text="@string/deposit_remains_yours"
+                            android:textSize="14sp" />
+                        <!-- endregion -->
+                    </LinearLayout>
+                </androidx.cardview.widget.CardView>
+                <!-- endregion -->
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/go_live_form_toggle_extra"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_marginTop="24dp"
+                android:layout_marginEnd="16dp"
+                style="@style/TextView_Light"
+                android:text="@string/show_extra_fields"
+                android:focusable="true" />
+
+            <!-- region: Cancel / Create Buttons -->
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:layout_marginTop="24dp">
+                <TextView
+                    android:id="@+id/go_live_form_cancel"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:layout_marginTop="24dp"
+                    style="@style/TextView_Light"
+                    android:text="@string/cancel" />
+
+                <ProgressBar
+                    android:id="@+id/go_live_form_creating"
+                    android:layout_centerVertical="true"
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_toStartOf="@id/go_live_form_create_button"
+                    android:visibility="gone" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/go_live_form_create_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_centerVertical="true"
+                    android:fontFamily="@font/inter"
+                    android:text="@string/create" />
+            </RelativeLayout>
+            <!-- endregion -->
+        </LinearLayout>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_livestreams.xml
+++ b/app/src/main/res/layout/fragment_livestreams.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/livestreams_server_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp">
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/livestreams_server_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:hint="@string/stream_server_title"
+            app:layout_constraintBottom_toTopOf="@+id/livestreams_key_text"
+            app:layout_constraintEnd_toStartOf="@+id/livestreams_server_copy_card"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/livestreams_server_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:cursorVisible="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                style="@style/TextView_Light"
+                android:textSize="14sp"
+                android:text="rtmp://stream.odysee.com/live"
+                tools:ignore="HardcodedText" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/livestreams_server_copy_card"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:cardCornerRadius="8dp"
+            app:layout_constraintBottom_toBottomOf="@+id/livestreams_server_text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintDimensionRatio="w,1:1">
+            <ImageButton
+                android:id="@+id/livestreams_server_copy"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/odyseePink"
+                android:padding="8dp"
+                android:src="@drawable/ic_copy"
+                android:contentDescription="@string/copy" />
+        </androidx.cardview.widget.CardView>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/livestreams_key_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/stream_key_title"
+            app:layout_constraintBottom_toTopOf="@id/livestreams_start_streaming"
+            app:layout_constraintEnd_toStartOf="@+id/livestreams_key_copy_card"
+            app:layout_constraintStart_toStartOf="parent">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/livestreams_key_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:cursorVisible="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:inputType="textPassword"
+                style="@style/TextView_Light"
+                android:textSize="14sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/livestreams_key_copy_card"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:cardCornerRadius="8dp"
+            app:layout_constraintBottom_toBottomOf="@+id/livestreams_key_text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/livestreams_key_text"
+            app:layout_constraintDimensionRatio="w,1:1">
+            <ImageButton
+                android:id="@+id/livestreams_key_copy"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/odyseePink"
+                android:padding="8dp"
+                android:src="@drawable/ic_copy"
+                android:contentDescription="@string/copy" />
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+            android:id="@+id/livestreams_key_show_link"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:paddingTop="4dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:textColor="@color/odyseePink"
+            style="@style/TextView_Light"
+            android:fontFamily="@font/inter"
+            android:textSize="14sp"
+            android:text="@string/show"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/livestreams_key_text" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/livestreams_start_streaming"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="@string/start_streaming"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/livestreams_server_info">
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/livestreams_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false" />
+
+        <RelativeLayout
+            android:id="@+id/livestreams_empty_container"
+            android:background="@color/pageBackground"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:padding="36dp">
+                <ImageView
+                    android:layout_gravity="center_horizontal"
+                    android:layout_width="160dp"
+                    android:layout_height="160dp"
+                    android:adjustViewBounds="true"
+                    android:src="@drawable/spaceman_happy" />
+                <TextView
+                    android:text="@string/no_livestreams"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:layout_gravity="center_horizontal"
+                    android:textAlignment="center"
+                    style="@style/TextView_SemiBold"
+                    android:textSize="18sp"/>
+                <TextView
+                    android:text="@string/no_livestreams_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_gravity="center_horizontal"
+                    style="@style/TextView_Light"
+                    android:textSize="16sp"/>
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/livestreams_create_button"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:fontFamily="@font/inter"
+                    android:text="@string/create_livestream"  />
+            </LinearLayout>
+        </RelativeLayout>
+    </RelativeLayout>
+
+    <ProgressBar
+        android:id="@+id/livestreams_list_loading"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_centerInParent="true"
+        android:visibility="gone" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/livestreams_create_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:src="@drawable/ic_add"
+        android:contentDescription="@string/create_livestream" />
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_replays_page.xml
+++ b/app/src/main/res/layout/fragment_replays_page.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <include
+        android:id="@+id/replays_page_first"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        layout="@layout/card_livestream_replay" />
+
+    <include
+        android:id="@+id/replays_page_second"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="invisible"
+        layout="@layout/card_livestream_replay" />
+
+    <include
+        android:id="@+id/replays_page_third"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="invisible"
+        layout="@layout/card_livestream_replay" />
+
+    <include
+        android:id="@+id/replays_page_fourth"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="invisible"
+        layout="@layout/card_livestream_replay" />
+</LinearLayout>

--- a/app/src/main/res/layout/popup_user.xml
+++ b/app/src/main/res/layout/popup_user.xml
@@ -96,34 +96,17 @@
             android:clickable="true"
             android:focusable="true"
             android:focusableInTouchMode="false"
-            android:id="@+id/button_go_live"
-            android:background="?android:selectableItemBackground"
-            android:layout_width="match_parent"
-            android:layout_height="40dp">
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_centerVertical="true"
-                android:layout_marginStart="40dp"
-                android:text="@string/go_live"
-                android:textSize="14sp"/>
-        </RelativeLayout>
-
-        <RelativeLayout
-            android:clickable="true"
-            android:focusable="true"
-            android:focusableInTouchMode="false"
             android:id="@+id/button_channels"
             android:background="?android:selectableItemBackground"
             android:layout_width="match_parent"
             android:layout_height="40dp">
             <TextView
-                android:layout_marginStart="40dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
+                android:layout_marginStart="40dp"
                 android:text="@string/channels"
-                android:textSize="14sp" />
+                android:textSize="14sp"/>
         </RelativeLayout>
 
         <RelativeLayout
@@ -157,6 +140,23 @@
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:text="@string/publishes"
+                android:textSize="14sp" />
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:clickable="true"
+            android:focusable="true"
+            android:focusableInTouchMode="false"
+            android:id="@+id/button_livestreams"
+            android:background="?android:selectableItemBackground"
+            android:layout_width="match_parent"
+            android:layout_height="40dp">
+            <TextView
+                android:layout_marginStart="40dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:text="@string/livestreams"
                 android:textSize="14sp" />
         </RelativeLayout>
 

--- a/app/src/main/res/menu/menu_upload.xml
+++ b/app/src/main/res/menu/menu_upload.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/action_upload"
+        android:title="@string/upload" />
+    <item android:id="@+id/action_go_live"
+        android:title="@string/go_live" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,9 @@
     <string name="your_tags">Your Tags</string>
     <string name="all_content">All Content</string>
     <string name="change_default_channel">Change default channel</string>
+    <string name="upload">Upload</string>
     <string name="go_live">Go Live</string>
+    <string name="livestreams">Livestreams</string>
     <string name="channels">Channels</string>
     <string name="creator_settings">Creator Settings</string>
     <string name="library">Library</string>
@@ -713,19 +715,28 @@
     <string name="no_added_tags">You have not added any tags yet. Add tags to improve discovery.</string>
     <string name="form_no_tag_results">We could not find new tags that have not been added yet.</string>
 
-    <!-- Go Live -->
-    <string name="precheck_please_wait">Please wait while we check a few things. If this is your first time, this may take a couple of minutes…</string>
-    <string name="precheck_need_channel">You need to create a channel before you can livestream.</string>
-    <string name="precheck_error_loading_channels">An error occurred loading your channels. Please try again later.</string>
-    <string name="precheck_wait_confirmation">Please wait, your livestream claim is pending confirmation.</string>
-    <string name="select_channel">Please select a channel</string>
-    <string name="channel_error_pending">Your channel is still pending. Please wait a couple of minutes and try again.</string>
-    <string name="channel_error_need_minimum_credits">You need to have at least %1$,.2f credits staked (directly or through supports) on %2$s to be able to livestream.</string>
-    <string name="error_publishing_livestream">An error occurred trying to set up your livestream. Please try again later.</string>
-    <string name="specify_title">Please specify a title for your livestream</string>
-    <string name="please_select_thumbnail">Please select a thumbnail</string>
-    <string name="need_valid_channel">Please select a valid channel to continue</string>
+    <!-- Livestreaming -->
+    <string name="create_livestream">Create a livestream</string>
+    <string name="edit_livestream">Edit livestream</string>
+    <string name="new_livestream">New livestream</string>
+    <string name="choose_replay">Choose replay</string>
+    <string name="date">Date</string>
+    <string name="anytime">Anytime</string>
+    <string name="scheduled_time">Scheduled time</string>
+    <string name="past_not_allowed">Cannot set to a time in the past.</string>
+    <string name="anytime_info">Confirmation process takes a few minutes, but then you can go live anytime. The stream is not shown anywhere until you are broadcasting.</string>
+    <string name="scheduled_info">Your scheduled streams will appear on your channel page and for your followers. Chat will not be active until 5 minutes before the start time.</string>
+    <string name="select_replay">Select replay</string>
+    <string name="no_replays">No replays available</string>
+    <string name="replay_processing">Processing… (%s%%)</string>
+    <string name="livestream_select_channel">Please select a channel to create a livestream.</string>
+    <string name="livestream_pending">Your livestream is now pending. You will be able to start shortly at the streaming dashboard.</string>
+    <string name="no_livestreams">No livestream publishes found</string>
+    <string name="no_livestreams_detail">You need to upload your livestream details before you can go live. Please note: Replays must be published manually after your stream by editing the livestream.</string>
     <string name="stream_key_not_generated">Your stream key could not be generated. Please try again later.</string>
+    <string name="stream_server_copied">Stream server copied</string>
+    <string name="stream_key_copied">Stream key copied</string>
+    <string name="no_stream_key_provided">No stream key was provided. This should not have happened.</string>
     <string name="stream_connect_failed">Could not establish a connection to the streaming URL. Please try again.</string>
     <string name="stream_connect_failed_retrying">Could not establish a connection to the streaming URL. Retrying…</string>
     <string name="camera_permission_rationale_livestream">Odysee requires access to your camera to livestream.</string>
@@ -735,6 +746,14 @@
     <string name="stream_stopped_went_to_home_reason">Because livestreaming sometimes doesn\'t resume properly after sleeping the device, your stream was automatically stopped.</string>
     <string name="confirm_stop_title">Stop streaming?</string>
     <string name="confirm_stop_message">Do you want to stop streaming?</string>
+    <string name="stream_server_title">Stream server</string>
+    <string name="stream_key_title">Stream key (can be reused)</string>
+    <string name="copy">Copy</string>
+    <string name="show">Show</string>
+    <plurals name="minutes">
+        <item quantity="one">%d minute</item>
+        <item quantity="other">%d minutes</item>
+    </plurals>
 
     <!-- Channels -->
     <string name="no_channel_created">You have not created a channel.\nStart now by creating a new channel!</string>
@@ -821,6 +840,7 @@
 
     <!-- Reward drivers -->
     <string name="publishing_requires_credits">Publishing requires credits.</string>
+    <string name="livestreaming_requires_credits">Livestreaming requires credits.</string>
     <string name="channel_creation_requires_credits">Channel creation requires credits.</string>
     <string name="earn_rewards_for_inviting">Earn rewards for inviting your friends.</string>
     <string name="earn_some_credits_to_access">Earn some credits to access this content.</string>


### PR DESCRIPTION
UX flow:
- Clicking the Upload button shows menu to pick Upload or Go Live
- Create livestreams with form like publishing
- Choose New Livestream or Upload Replay Replays shown in pages of 4 like on odysee.com
- Choose Anytime or Scheduled Time stream
- Clicking the Create button goes to livestreams dashboard (also accessible from user menu)
- Livestreams dashboard shows stream server and stream key, with button to copy
- Dashboard waits for created claim to finish confirming then enables Start Streaming button
- Clicking Start Streaming goes to activity that streams with HaishinKit
- Streaming activity sets `FLAG_KEEP_SCREEN_ON` in `onCreate` instead of when streaming starts. Also removes flag only `onDestroy`.

Changes of note:
- There are now 3 publish tasks:
  - `PublishClaimTask` uses the LBRY API
  - `ReplayPublishTask` uses the v1 Odysee Publish API
  - `TusPublishTask` uses the v2 Odysee Publish API (uses Tus for upload)
- Add `buildPublishOptions` function in `Helper` to create options map from
  `Claim`.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Fix: #93
Fix: #94
Fix (partial): #232 (`app reloading after accepting permissions to camera/audio when trying to go live`)

## To Review/Discuss

- App crashes when in `GoLiveForm` and changing between Light/Dark mode.
  This is because `ReplaysPageFragment` doesn't get recreated from the adapter, so the `replays` list is `null`. I wasn't able to figure out how to get the adapter to reinit the fragment.
- App crashes if quickly pressing back after going to `GoLiveForm`, due to the `ReplaysPagerAdapter` not being able to access the fragment manager (in the constructor).
- The replays picker (`ReplaysPageFragment`) is currently the same height always, even if there's less than 4 replays on a page. It will be a bit of effort to support dynamically changing the height. Is this necessary?
- Should `GoLiveActivity` be renamed (because it's only used for HaishinKit streaming)?
