### PR TITLE
Pass token to ClaimListTask when fetching own claims

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -4527,7 +4527,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public void fetchOwnClaims() {
         Map<String, Object> options = Lbry.buildClaimListOptions(
                 Arrays.asList(Claim.TYPE_STREAM, Claim.TYPE_REPOST), 1, 999, true);
-        ClaimListTask task = new ClaimListTask(options, null, new ClaimListResultHandler() {
+        ClaimListTask task = new ClaimListTask(options, Lbryio.AUTH_TOKEN, null, new ClaimListResultHandler() {
             @Override
             public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
                 Lbry.ownClaims = Helper.filterDeletedClaims(new ArrayList<>(claims));


### PR DESCRIPTION
Fix `Lbry.ownClaims` being `null` because `ClaimListTask` failed without token

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

`fetchOwnClaims` fails so `Lbry.ownClaims` is `null`.

## What is the new behavior?

`fetchOwnClaims` fixed.
