### PR TITLE
issue_template: use correct chat link

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -5,7 +5,7 @@ To make it possible for us to help you, please fill out below information carefu
 
 Before reporting any issues, please make sure that you're using the latest version.
 
-We are also available on live chat at https://chat.lbry.com
+We are also available on live chat at https://chat.odysee.com
 --> 
 
 
@@ -17,10 +17,10 @@ We are also available on live chat at https://chat.lbry.com
 3.
 
 ### Expected behaviour
-Tell us what should happen
+<!-- Tell us what should happen -->
 
 ### Actual behaviour
-Tell us what happens instead
+<!-- Tell us what happens instead -->
 
 
 ## System Configuration
@@ -43,7 +43,7 @@ Tell us what happens instead
 3.
 
 ### Definition of Done
-- [ ]  Tested against acceptance criteria
+- [ ] Tested against acceptance criteria
 - [ ] Tested against the assumptions of the user story
 - [ ] The project builds without errors
 - [ ] Unit tests are written and passing


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Other - Please describe:

## Fixes

Issue Number: N/A

## What is the current behavior?

Link is `chat.lbry.com`, which goes to the LBRY Discord

## What is the new behavior?

Use `chat.odysee.com` link, which goes to the Odysee Discord
