### PR TITLE
player: don't set newPlayerCreated when playerManager initialized

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -1137,6 +1137,7 @@ public class FileViewFragment extends BaseFragment implements
             PlayerView view = root.findViewById(R.id.file_view_exoplayer_view);
             view.setVisibility(View.VISIBLE);
             Player currentPlayer = MainActivity.playerManager.getCurrentPlayer();
+            view.setPlayer(null);
             view.setPlayer(currentPlayer);
             view.setControllerHideOnTouch(currentPlayer instanceof ExoPlayer);
             view.setControllerShowTimeoutMs(currentPlayer instanceof ExoPlayer
@@ -2488,22 +2489,22 @@ public class FileViewFragment extends BaseFragment implements
 
                 activity.initMediaSession();
                 activity.initPlaybackNotification();
-            }
 
-            MainActivity.playerManager.setListener(new PlayerManager.Listener() {
-                @Override
-                public void onPlayerChanged(long previousPlaybackMs) {
-                    if (!Helper.isNullOrEmpty(currentMediaSourceUrl)) {
-                        MainActivity.playerManager.initializeCurrentPlayer(
-                                currentMediaSourceUrl, previousPlaybackMs, fileClaim, context);
+                MainActivity.playerManager.setListener(new PlayerManager.Listener() {
+                    @Override
+                    public void onPlayerChanged(long previousPlaybackMs) {
+                        if (!Helper.isNullOrEmpty(currentMediaSourceUrl)) {
+                            MainActivity.playerManager.initializeCurrentPlayer(
+                                    currentMediaSourceUrl, previousPlaybackMs, fileClaim, context);
+                        }
+                        setPlayerForPlayerView();
+                        activity.initMediaSession();
+                        activity.initPlaybackNotification();
                     }
-                    setPlayerForPlayerView();
-                    activity.initMediaSession();
-                    activity.initPlaybackNotification();
-                }
-            });
+                });
 
-            newPlayerCreated = true;
+                newPlayerCreated = true;
+            }
         }
 
         Claim claimToPlay = collectionClaimItem != null ? collectionClaimItem : fileClaim;


### PR DESCRIPTION
When newPlayerCreated is set to true, streaming url is refetched and playback is restarted.

Also call setPlayer(null) in setPlayerForPlayerView. Without this playback freezes when returning from picture in picture.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Fix: #356

## What is the current behavior?

Playback restarts when going from mini player -> main player.
Playback freezes when returning from picture in picture.

## What is the new behavior?

Playback doesn't restart, doesn't freeze.
