### PR TITLE
claim: use name if title is null in getTitleOrName

### DIFF
--- a/app/src/main/java/com/odysee/app/model/Claim.java
+++ b/app/src/main/java/com/odysee/app/model/Claim.java
@@ -326,7 +326,10 @@ public class Claim {
         return (value != null) ? value.getTitle() : null;
     }
     public String getTitleOrName() {
-        return (value != null) ? value.getTitle() : getName();
+        if (value != null && value.getTitle() != null) {
+            return value.getTitle();
+        }
+        return getName();
     }
 
     public long getDuration() {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## Fixes

Issue Number: N/A

## What is the current behavior?

If channel has a `value` but `value.title` is `null`, the publisher doesn't have any text

## What is the new behavior?

Use `name` if `value.title` is null.
