### PR TITLE
Unlock screen rotation from API Level 31 devices

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -529,9 +529,11 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         setContentView(R.layout.activity_main);
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            //noinspection deprecation
             findViewById(R.id.root).setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
             findViewById(R.id.launch_splash).setVisibility(View.VISIBLE);
         } else {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
             findViewById(R.id.root).getViewTreeObserver().addOnPreDrawListener(
                 new ViewTreeObserver.OnPreDrawListener() {
                     @Override


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #359

## What is the current behavior?
On devices running up to Android 11, a splash screen is displayed in a forced portrait orientation. From Android 12 the splash screen is displayed by the OS. This causes to keep tghe screen orientation locked into portrait mode although the custom splash screen is not displayed by the app.
## What is the new behavior?
From Android 12, the screen is unlocked to current orientation.
## Other information
Android OS still shows the activity in a locked portrait mode for a few seconds. This PR unlocks it at the earliest moment on code. Trying to move the setRequestedOrientation a few lines before will not fix the issue.
