### PR TITLE
file view: remove not loading reactions on livestreams

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2789,10 +2789,6 @@ public class FileViewFragment extends BaseFragment implements
             futureReactions.cancel(true);
         }
 
-        if (c.isLive()) {
-            return;
-        }
-
         Activity a = getActivity();
 
         if (a != null) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Reactions don't load on livestreams, clicking reaction buttons crash due to reaction being `null`.

## What is the new behavior?

Load reactions on livestreams.

## Other information

@kekkyojin why was this block added? I tested and this PR works on both livestreams and normal claims.