### PR TITLE
file view: don't hide global player

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -1016,6 +1016,7 @@ public class FileViewFragment extends BaseFragment implements
             activity.findViewById(R.id.appbar).setFitsSystemWindows(false);
             activity.checkIfPlaylistOverlayShouldDisplay();
             activity.refreshChannelCreationRequired(getView());
+            activity.updateMiniPlayerMargins(false);
         }
 
         if (MainActivity.playerManager != null) {
@@ -4392,11 +4393,6 @@ public class FileViewFragment extends BaseFragment implements
             }
         }
         return false;
-    }
-
-    @Override
-    public boolean shouldHideGlobalPlayer() {
-        return true;
     }
 
     private void checkOwnClaim() {


### PR DESCRIPTION
Instead only hide it when playing another video/viewing content.

Update mini player bottom margins when starting file view fragment.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Mini player disappears (but video still plays) when opening another claim.

## What is the new behavior?

Only hide mini player when starting playback of another file.
