### PR TITLE
Show livestreams also for Rabbit Hole category

### DIFF
--- a/app/src/main/java/com/odysee/app/callable/GetAllLivestreams.java
+++ b/app/src/main/java/com/odysee/app/callable/GetAllLivestreams.java
@@ -1,0 +1,61 @@
+package com.odysee.app.callable;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class GetAllLivestreams implements Callable<Map<String, JSONObject>> {
+    @Override
+    public Map<String, JSONObject> call() throws Exception {
+        final String ODYSEE_LIVESTREAM_ALL_API = "https://api.odysee.live/livestream/all";
+        Map<String, JSONObject> streamingChannels = new HashMap<>();
+        Request.Builder builder = new Request.Builder();
+        OkHttpClient client = new OkHttpClient.Builder().build();
+        builder.url(ODYSEE_LIVESTREAM_ALL_API);
+        Request request = builder.build();
+
+        JSONArray jsonData;
+
+        try (Response resp = client.newCall(request).execute()) {
+            ResponseBody body = resp.body();
+            int responseCode = resp.code();
+
+            if (body != null && responseCode >= 200 && responseCode < 300) {
+                String responseString = body.string();
+
+                resp.close();
+
+                JSONObject json = new JSONObject(responseString);
+                if (!json.isNull("data") && (json.has("success") && json.getBoolean("success"))) {
+                    jsonData = json.getJSONArray("data");
+
+                    int s = jsonData.length();
+
+                    for (int i = 0; i < s; i++) {
+                        JSONObject channelData = jsonData.getJSONObject(i);
+
+                        // On the livestreams/all API call, all returned channels are expected to be live,
+                        // but let's check it, just in case.
+                        if (channelData.has("ChannelClaimID") && channelData.has("Live") && channelData.getBoolean("Live")) {
+                            streamingChannels.put(channelData.getString("ChannelClaimID"), channelData);
+                        }
+                    }
+                }
+            }
+        } catch (IOException | JSONException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+        return streamingChannels;
+    }
+}

--- a/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
@@ -23,6 +23,7 @@ import com.google.android.material.chip.ChipGroup;
 
 import com.odysee.app.OdyseeApp;
 import com.odysee.app.callable.ChannelLiveStatus;
+import com.odysee.app.callable.GetAllLivestreams;
 import com.odysee.app.callable.Search;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -653,11 +654,21 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
         List<Claim> subscribedActiveClaims = new ArrayList<>();
         if (a != null) {
             try {
-                List<String> channelIds = Arrays.asList(currentChannelIdList);
+                Map<String, JSONObject> activeJsonData;
+                Callable<Map<String, JSONObject>> callable;
+                Future<Map<String, JSONObject>> futureActive;
 
-                Callable<Map<String, JSONObject>> callable = new ChannelLiveStatus(channelIds, false, true);
-                Future<Map<String, JSONObject>> futureActive = ((OdyseeApp) a.getApplication()).getExecutor().submit(callable);
-                Map<String, JSONObject> activeJsonData = futureActive.get();
+                if (currentCategoryId != wildWestIndex) {
+                    List<String> channelIds = Arrays.asList(currentChannelIdList);
+
+                    callable = new ChannelLiveStatus(channelIds, false, true);
+                    futureActive = ((OdyseeApp) a.getApplication()).getExecutor().submit(callable);
+                } else {
+                    callable = new GetAllLivestreams();
+                    futureActive = ((OdyseeApp) a.getApplication()).getExecutor().submit(callable);
+                }
+
+                activeJsonData = futureActive.get();
 
                 if (activeJsonData != null && activeJsonData.size() > 0) {
                     List<String> claimIds = new ArrayList<>();
@@ -732,7 +743,7 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
                 null,
                 canShowMatureContent ? null : new ArrayList<>(Predefined.MATURE_TAGS),
                 null,
-                Arrays.asList(currentChannelIdList),
+                currentCategoryId != wildWestIndex ? Arrays.asList(currentChannelIdList) : null,
                 Arrays.asList(dynamicCategories.get(currentCategoryId).getExcludedChannelIds()),
                 null,
                 null,


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Active livestreams are shown on each category except on the Rabbit Hole one
## What is the new behavior?
Livestreams are also shown on Rabbit Hole category