### PR TITLE
Publish/Go Live form fixes

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/publish/GoLiveFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/GoLiveFormFragment.java
@@ -668,7 +668,7 @@ public class GoLiveFormFragment extends BaseFragment implements
         fetchingChannels = true;
         disableChannelSpinner();
         Map<String, Object> options = Lbry.buildClaimListOptions(Claim.TYPE_CHANNEL, 1, 999, true);
-        ClaimListTask task = new ClaimListTask(options, progressLoadingChannels, new ClaimListResultHandler() {
+        ClaimListTask task = new ClaimListTask(options, Lbryio.AUTH_TOKEN, progressLoadingChannels, new ClaimListResultHandler() {
             @Override
             public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
                 Lbry.ownChannels = new ArrayList<>(claims);
@@ -692,14 +692,6 @@ public class GoLiveFormFragment extends BaseFragment implements
 
     private void enableChannelSpinner() {
         Helper.setViewEnabled(channelSpinner, true);
-        if (channelSpinner != null) {
-            Claim selectedClaim = (Claim) channelSpinner.getSelectedItem();
-            if (selectedClaim != null) {
-                if (selectedClaim.isPlaceholder()) {
-                    showChannelCreator();
-                }
-            }
-        }
     }
 
     private void showChannelCreator() {

--- a/app/src/main/java/com/odysee/app/ui/publish/GoLiveFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/GoLiveFormFragment.java
@@ -169,7 +169,6 @@ public class GoLiveFormFragment extends BaseFragment implements
     private String uploadedThumbnailUrl;
     private boolean storageRefusedOnce;
     private boolean editFieldsLoaded;
-    private boolean editChannelSpinnerLoaded;
     private boolean editMode;
     private boolean modeLivestream = true;
     private boolean anytimeStream = true;
@@ -732,12 +731,11 @@ public class GoLiveFormFragment extends BaseFragment implements
 
         if (channelSpinnerAdapter != null && channelSpinner != null) {
             if (editMode) {
-                if (currentClaim.getSigningChannel() != null && !editChannelSpinnerLoaded) {
+                if (currentClaim.getSigningChannel() != null) {
                     int position = channelSpinnerAdapter.getItemPosition(currentClaim.getSigningChannel());
                     if (position > -1) {
                         channelSpinner.setSelection(position);
                     }
-                    editChannelSpinnerLoaded = true;
                 }
             } else {
                 if (channelSpinnerAdapter.getCount() > 1) {

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
@@ -175,7 +175,6 @@ public class PublishFormFragment extends BaseFragment implements
     private String lastSelectedThumbnailFile;
     private String uploadedThumbnailUrl;
     private boolean editFieldsLoaded;
-    private boolean editChannelSpinnerLoaded;
     private Claim currentClaim;
     private GalleryItem currentGalleryItem;
     private String currentFilePath;
@@ -1071,17 +1070,14 @@ public class PublishFormFragment extends BaseFragment implements
 
         if (channelSpinnerAdapter != null && channelSpinner != null) {
             if (editMode) {
-                if (!editChannelSpinnerLoaded) {
-                    if (currentClaim.getSigningChannel() != null) {
-                        int position = channelSpinnerAdapter.getItemPosition(currentClaim.getSigningChannel());
-                        if (position > -1) {
-                            channelSpinner.setSelection(position);
-                        }
-                    } else {
-                        // select anonymous
-                        channelSpinner.setSelection(1);
+                if (currentClaim.getSigningChannel() != null) {
+                    int position = channelSpinnerAdapter.getItemPosition(currentClaim.getSigningChannel());
+                    if (position > -1) {
+                        channelSpinner.setSelection(position);
                     }
-                    editChannelSpinnerLoaded = true;
+                } else {
+                    // select anonymous
+                    channelSpinner.setSelection(1);
                 }
             } else {
                 if (channelSpinnerAdapter.getCount() > 2) {

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishFormFragment.java
@@ -1010,7 +1010,7 @@ public class PublishFormFragment extends BaseFragment implements
         fetchingChannels = true;
         disableChannelSpinner();
         Map<String, Object> options = Lbry.buildClaimListOptions(Claim.TYPE_CHANNEL, 1, 999, true);
-        ClaimListTask task = new ClaimListTask(options, progressLoadingChannels, new ClaimListResultHandler() {
+        ClaimListTask task = new ClaimListTask(options, Lbryio.AUTH_TOKEN, progressLoadingChannels, new ClaimListResultHandler() {
             @Override
             public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
                 Lbry.ownChannels = new ArrayList<>(claims);
@@ -1032,14 +1032,6 @@ public class PublishFormFragment extends BaseFragment implements
     }
     private void enableChannelSpinner() {
         Helper.setViewEnabled(channelSpinner, true);
-        if (channelSpinner != null) {
-            Claim selectedClaim = (Claim) channelSpinner.getSelectedItem();
-            if (selectedClaim != null) {
-                if (selectedClaim.isPlaceholder()) {
-                    showChannelCreator();
-                }
-            }
-        }
     }
     private void showChannelCreator() {
         MainActivity activity = (MainActivity) getActivity();


### PR DESCRIPTION
### Commits:

#### claim edit: fix channel creator getting shown when fragment resumes 

Always set channel from claim even after first load from claim data.

#### publish: fix nothing shown in channel selector when there's no channels 
Expected to show "Create a channel" and Anonymous, but they're not
because the ClaimListTask which later calls the method to populate with
placeholder claims fails.

Remove code for showing channel creator from enableChannelSpinner(),
it's already handled in the spinner onItemSelectedListener.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Channel creator shown when turning off then on screen while editing claim.

If account has no channels, going live doesn't show the channel creator and channel spinner has no values, when there should be a "Create a channel" placeholder.
