### PR TITLE
blocked & muted view: fix listing blocked and blocking/unblocking

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/other/BlockedAndMutedFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/other/BlockedAndMutedFragment.java
@@ -172,7 +172,7 @@ public class BlockedAndMutedFragment extends BaseFragment {
 
                             JSONObject result = Helper.getJSONObject("result", jsonResponse);
                             if (!result.has("blocked_channels") || result.isNull("blocked_channels")) {
-                                throw new ApiCallException("missing blocked_channels key from json response");
+                                continue;
                             }
 
                             JSONArray items = result.getJSONArray("blocked_channels");
@@ -318,10 +318,9 @@ public class BlockedAndMutedFragment extends BaseFragment {
     public boolean onContextItemSelected(MenuItem item) {
         if (item.getGroupId() == BLOCKED_AND_MUTED_CONTEXT_GROUP_ID && (item.getItemId() == R.id.action_block || item.getItemId() == R.id.action_mute)) {
             if (adapter != null) {
-                int position = adapter.getPosition();
-                Claim claim = adapter.getItems().get(position);
-                if (claim != null && claim.getSigningChannel() != null) {
-                    Claim channel = claim.getSigningChannel();
+                int position = adapter.getCurrentPosition();
+                Claim channel = adapter.getItems().get(position);
+                if (channel != null) {
                     boolean isBlocked = Lbryio.isChannelBlocked(channel);
                     boolean isMuted = Lbryio.isChannelMuted(channel);
 
@@ -329,14 +328,14 @@ public class BlockedAndMutedFragment extends BaseFragment {
                     if (context instanceof MainActivity) {
                         MainActivity activity = (MainActivity) context;
                         if (item.getItemId() == R.id.action_block) {
-                            if (!isBlocked) {
+                            if (isBlocked) {
                                 activity.handleUnblockChannel(channel, null);
                             } else {
                                 activity.handleBlockChannel(channel, null);
                             }
                         } else {
-                            if (!isMuted) {
-                                activity.handleMuteChannel(channel);
+                            if (isMuted) {
+                                activity.handleUnmuteChannel(channel);
                             } else {
                                 activity.handleMuteChannel(channel);
                             }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

If one of your channels doesn't have any blocked channels, an error "missing blocked_channels key from json response" is thrown and blocked channels aren't listed.

(Un)blocking/(un)muting channels doesn't work.

## What is the new behavior?

Just skip single channel if it has no blocked channels instead of throwing an error and stopping checking on all channels.

Don't get signing_channel on claims to unblock/unmute as only channels can be blocked/muted so there's no file claims in the adapter.

Fix inverted and broken logic in context menu actions.
