### PR TITLE
claim context menu: add Report action, implement handlers on all screens

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -107,6 +107,8 @@ import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.view.ActionMode;
+import androidx.browser.customtabs.CustomTabColorSchemeParams;
+import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
@@ -5575,6 +5577,16 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 }
             }
         });
+    }
+
+    public void handleReportClaim(final Claim claim) {
+        CustomTabColorSchemeParams.Builder ctcspb = new CustomTabColorSchemeParams.Builder();
+        ctcspb.setToolbarColor(ContextCompat.getColor(this, R.color.colorPrimary));
+        CustomTabColorSchemeParams ctcsp = ctcspb.build();
+
+        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder().setDefaultColorSchemeParams(ctcsp);
+        CustomTabsIntent intent = builder.build();
+        intent.launchUrl(this, Uri.parse(String.format("https://odysee.com/$/report_content?claimId=%s", claim.getClaimId())));
     }
 
     public void setPlayerQuality(Player player, int quality) {

--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -62,11 +62,6 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
 
     private float scale;
 
-    /**
-     * Note: This is only a flag to check for certain conditions and handle the behaviour differently on the playlist fragment
-     */
-    @Setter
-    private boolean longClickForContextMenu;
     @Getter
     @Setter
     private boolean inPlaylistOverlay;
@@ -360,6 +355,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
 
             contextMenu.add(contextGroupId, R.id.action_block, Menu.NONE, isBlocked ? R.string.unblock_channel : R.string.block_channel);
             contextMenu.add(contextGroupId, R.id.action_mute, Menu.NONE, isMuted ? R.string.unmute_channel : R.string.mute_channel);
+            contextMenu.add(contextGroupId, R.id.action_report, Menu.NONE, R.string.report);
         }
     }
 
@@ -547,10 +543,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         vh.itemView.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View view) {
-                if (longClickForContextMenu) {
-                    setCurrentPosition(vh.getAbsoluteAdapterPosition());
-                    return false;
-                }
+                setCurrentPosition(vh.getAbsoluteAdapterPosition());
 
                 if (!canEnterSelectionMode) {
                     return false;

--- a/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
@@ -773,7 +773,7 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
     public boolean onContextItemSelected(MenuItem item) {
         if (item.getGroupId() == ALL_CONTENT_CONTEXT_GROUP_ID && (item.getItemId() == R.id.action_block || item.getItemId() == R.id.action_mute)) {
             if (contentListAdapter != null) {
-                int position = contentListAdapter.getPosition();
+                int position = contentListAdapter.getCurrentPosition();
                 Claim claim = contentListAdapter.getItems().get(position);
                 if (claim != null && claim.getSigningChannel() != null) {
                     Claim channel = claim.getSigningChannel();
@@ -791,9 +791,21 @@ public class AllContentFragment extends BaseFragment implements DownloadActionLi
             return true;
         }
 
-        if (item.getGroupId() ==  ALL_CONTENT_CONTEXT_GROUP_ID)  {
+        if (item.getGroupId() == ALL_CONTENT_CONTEXT_GROUP_ID && item.getItemId() == R.id.action_report) {
             if (contentListAdapter != null) {
-                int position = contentListAdapter.getPosition();
+                int position = contentListAdapter.getCurrentPosition();
+                Claim claim = contentListAdapter.getItems().get(position);
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    ((MainActivity) context).handleReportClaim(claim);
+                }
+            }
+            return true;
+        }
+
+        if (item.getGroupId() == ALL_CONTENT_CONTEXT_GROUP_ID)  {
+            if (contentListAdapter != null) {
+                int position = contentListAdapter.getCurrentPosition();
                 Claim claim = contentListAdapter.getItems().get(position);
                 String url = claim.getPermanentUrl();
 

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -4332,7 +4332,7 @@ public class FileViewFragment extends BaseFragment implements
     public boolean onContextItemSelected(MenuItem item) {
         if (item.getGroupId() == FILE_CONTEXT_GROUP_ID && (item.getItemId() == R.id.action_block || item.getItemId() == R.id.action_mute)) {
             if (relatedContentAdapter != null) {
-                int position = relatedContentAdapter.getPosition();
+                int position = relatedContentAdapter.getCurrentPosition();
                 Claim claim = relatedContentAdapter.getItems().get(position);
                 if (claim != null && claim.getSigningChannel() != null) {
                     Claim channel = claim.getSigningChannel();
@@ -4348,9 +4348,21 @@ public class FileViewFragment extends BaseFragment implements
             return true;
         }
 
+        if (item.getGroupId() == FILE_CONTEXT_GROUP_ID && item.getItemId() == R.id.action_report) {
+            if (relatedContentAdapter != null) {
+                int position = relatedContentAdapter.getCurrentPosition();
+                Claim claim = relatedContentAdapter.getItems().get(position);
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    ((MainActivity) context).handleReportClaim(claim);
+                }
+            }
+            return true;
+        }
+
         if (item.getGroupId() ==  FILE_CONTEXT_GROUP_ID)  {
             if (relatedContentAdapter != null) {
-                int position = relatedContentAdapter.getPosition();
+                int position = relatedContentAdapter.getCurrentPosition();
                 Claim claim = relatedContentAdapter.getItems().get(position);
                 String url = claim.getPermanentUrl();
 

--- a/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/SearchFragment.java
@@ -45,6 +45,7 @@ import com.odysee.app.listener.DownloadActionListener;
 import com.odysee.app.model.Claim;
 import com.odysee.app.model.ClaimCacheKey;
 import com.odysee.app.model.LbryFile;
+import com.odysee.app.model.OdyseeCollection;
 import com.odysee.app.tasks.claim.ResolveResultHandler;
 import com.odysee.app.tasks.claim.ResolveTask;
 import com.odysee.app.ui.BaseFragment;
@@ -257,19 +258,59 @@ public class SearchFragment extends BaseFragment implements
 
     @Override
     public boolean onContextItemSelected(MenuItem item) {
-        if (item.getGroupId() == SEARCH_CONTEXT_GROUP_ID && item.getItemId() == R.id.action_block) {
+        if (item.getGroupId() == SEARCH_CONTEXT_GROUP_ID && (item.getItemId() == R.id.action_block || item.getItemId() == R.id.action_mute)) {
             if (resultListAdapter != null) {
-                int position = resultListAdapter.getPosition();
+                int position = resultListAdapter.getCurrentPosition();
                 Claim claim = resultListAdapter.getItems().get(position);
-                if (claim != null && claim.getSigningChannel() != null) {
-                    Claim channel = claim.getSigningChannel();
+                if (claim != null) {
+                    Claim channel = claim.getSigningChannel() != null ? claim.getSigningChannel() : claim;
                     Context context = getContext();
                     if (context instanceof MainActivity) {
-                        ((MainActivity) context).handleMuteChannel(channel);
+                        MainActivity activity = (MainActivity) context;
+                        if (item.getItemId() == R.id.action_block) {
+                            activity.handleBlockChannel(channel, null);
+                        } else {
+                            activity.handleMuteChannel(channel);
+                        }
                     }
                 }
             }
             return true;
+        }
+
+        if (item.getGroupId() == SEARCH_CONTEXT_GROUP_ID && item.getItemId() == R.id.action_report) {
+            if (resultListAdapter != null) {
+                int position = resultListAdapter.getCurrentPosition();
+                Claim claim = resultListAdapter.getItems().get(position);
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    ((MainActivity) context).handleReportClaim(claim);
+                }
+            }
+            return true;
+        }
+
+        if (item.getGroupId() == SEARCH_CONTEXT_GROUP_ID)  {
+            if (resultListAdapter != null) {
+                int position = resultListAdapter.getCurrentPosition();
+                Claim claim = resultListAdapter.getItems().get(position);
+
+                String url = claim.getPermanentUrl();
+
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    MainActivity activity = (MainActivity) context;
+                    if (item.getItemId() == R.id.action_add_to_watch_later) {
+                        activity.handleAddUrlToList(url, OdyseeCollection.BUILT_IN_ID_WATCHLATER);
+                    } else if (item.getItemId() == R.id.action_add_to_favorites) {
+                        activity.handleAddUrlToList(url, OdyseeCollection.BUILT_IN_ID_FAVORITES);
+                    } else if (item.getItemId() == R.id.action_add_to_lists) {
+                        activity.handleAddUrlToList(url, null);
+                    } else if (item.getItemId() == R.id.action_add_to_queue) {
+                        activity.handleAddToNowPlayingQueue(claim);
+                    }
+                }
+            }
         }
 
         return super.onContextItemSelected(item);

--- a/app/src/main/java/com/odysee/app/ui/library/PlaylistFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/library/PlaylistFragment.java
@@ -264,7 +264,6 @@ public class PlaylistFragment extends BaseFragment implements
                 collection.setClaims(new ArrayList<>(playlistClaimMap.values()));
 
                 adapter = new ClaimListAdapter(collection.getClaims(), ClaimListAdapter.STYLE_SMALL_LIST, getContext());
-                adapter.setLongClickForContextMenu(true);
                 adapter.setOwnCollection(true);
                 adapter.setListener(new ClaimListAdapter.ClaimListItemListener() {
                     @Override
@@ -352,6 +351,24 @@ public class PlaylistFragment extends BaseFragment implements
 
     @Override
     public boolean onContextItemSelected(@NonNull MenuItem item) {
+        if (currentCollection != null && (item.getItemId() == R.id.action_block || item.getItemId() == R.id.action_mute)) {
+            int position = adapter.getCurrentPosition();
+            Claim claim = adapter.getItems().get(position);
+            if (claim != null && claim.getSigningChannel() != null) {
+                Claim channel = claim.getSigningChannel();
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    MainActivity activity = (MainActivity) context;
+                    if (item.getItemId() == R.id.action_block) {
+                        activity.handleBlockChannel(channel, null);
+                    } else {
+                        activity.handleMuteChannel(channel);
+                    }
+                }
+            }
+            return true;
+        }
+
         if (currentCollection != null && item.getItemId() == R.id.action_remove_from_list) {
             String id = currentCollection.getId();
             int position = adapter.getCurrentPosition();
@@ -372,6 +389,17 @@ public class PlaylistFragment extends BaseFragment implements
                 }
             }
         }
+
+        if (currentCollection != null && item.getItemId() == R.id.action_report) {
+            int position = adapter.getCurrentPosition();
+            Claim claim = adapter.getItems().get(position);
+            Context context = getContext();
+            if (context instanceof MainActivity) {
+                ((MainActivity) context).handleReportClaim(claim);
+            }
+            return true;
+        }
+
         return super.onContextItemSelected(item);
     }
 

--- a/app/src/main/java/com/odysee/app/ui/other/BlockedAndMutedFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/other/BlockedAndMutedFragment.java
@@ -347,6 +347,18 @@ public class BlockedAndMutedFragment extends BaseFragment {
             return true;
         }
 
+        if (item.getGroupId() == BLOCKED_AND_MUTED_CONTEXT_GROUP_ID && item.getItemId() == R.id.action_report) {
+            if (adapter != null) {
+                int position = adapter.getCurrentPosition();
+                Claim claim = adapter.getItems().get(position);
+                Context context = getContext();
+                if (context instanceof MainActivity) {
+                    ((MainActivity) context).handleReportClaim(claim);
+                }
+            }
+            return true;
+        }
+
         return super.onContextItemSelected(item);
     }
 

--- a/app/src/main/res/menu/menu_stream.xml
+++ b/app/src/main/res/menu/menu_stream.xml
@@ -43,4 +43,10 @@
         android:title="@string/mute_channel"
         app:iconTint="@color/actionBarForeground"
         app:showAsAction="always" />
+    <item
+        android:id="@+id/action_report"
+        android:icon="@drawable/ic_report"
+        android:title="@string/report"
+        app:iconTint="@color/actionBarForeground"
+        app:showAsAction="always" />
 </menu>


### PR DESCRIPTION
Currently, although all context menu actions are shown when opening the context menu on claims on any screen, for most screens the actions don't do anything. Implement the functionality for all screens.

In ClaimListAdapter, remove the longClickForContextMenu flag and always set currentPosition to the item's absolute position in the adapter when a long press occurs. In the context menu listeners, use getCurrentPosition() instead of getPosition() as the latter doesn't return the correct value on a long press.

On the search page, check if a claim is a channel, and if so don't attempt to get its signing channel when blocking/muting.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## Fixes

Issue Number: N/A
