### PR TITLE
chromecast: remove app bar cast button and introductory overlay

### DIFF
--- a/app/src/foss/java/com/odysee/app/utils/CastHelper.java
+++ b/app/src/foss/java/com/odysee/app/utils/CastHelper.java
@@ -5,7 +5,7 @@ import android.app.Activity;
 import androidx.mediarouter.app.MediaRouteButton;
 
 public class CastHelper {
-    public CastHelper(Activity context, MediaRouteButton introductoryOverlayButton, Listener listener) { }
+    public CastHelper(Activity context, Listener listener) { }
 
     public void setUpCastButton(MediaRouteButton mediaRouteButton) { }
 

--- a/app/src/full/java/com/odysee/app/utils/CastHelper.java
+++ b/app/src/full/java/com/odysee/app/utils/CastHelper.java
@@ -8,43 +8,18 @@ import com.google.android.gms.cast.framework.CastButtonFactory;
 import com.google.android.gms.cast.framework.CastContext;
 import com.google.android.gms.cast.framework.CastState;
 import com.google.android.gms.cast.framework.CastStateListener;
-import com.google.android.gms.cast.framework.IntroductoryOverlay;
-import com.odysee.app.R;
 
 public class CastHelper {
     private final Activity context;
     private final CastContext castContext;
     private final CastStateListener castStateListener;
-    private IntroductoryOverlay introductoryOverlay;
 
-    public CastHelper(Activity context, MediaRouteButton introductoryOverlayButton, Listener listener) {
+    public CastHelper(Activity context, Listener listener) {
         this.context = context;
 
         castContext = CastContext.getSharedInstance(context);
 
-        castStateListener = new CastStateListener() {
-            @Override
-            public void onCastStateChanged(int state) {
-                boolean isVisible = state != CastState.NO_DEVICES_AVAILABLE;
-                listener.updateMediaRouteButtonVisibility(isVisible);
-                if (isVisible) {
-                    if (introductoryOverlay != null) {
-                        introductoryOverlay.remove();
-                    }
-                    introductoryOverlay = new IntroductoryOverlay.Builder(context, introductoryOverlayButton)
-                            .setTitleText(R.string.cast_introductory_overlay_text)
-                            .setSingleTime()
-                            .setOnOverlayDismissedListener(new IntroductoryOverlay.OnOverlayDismissedListener() {
-                                @Override
-                                public void onOverlayDismissed() {
-                                    introductoryOverlay = null;
-                                }
-                            })
-                            .build();
-                    introductoryOverlay.show();
-                }
-            }
-        };
+        castStateListener = state -> listener.updateMediaRouteButtonVisibility(state != CastState.NO_DEVICES_AVAILABLE);
     }
 
     public void setUpCastButton(MediaRouteButton mediaRouteButton) {

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -318,7 +318,6 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public static Cache playerCache;
     public static boolean playerReassigned;
     public boolean mediaRouteButtonVisible;
-    public MediaRouteButton appBarMediaRouteButton;
     public MediaRouteButton playerMediaRouteButton;
     public static int nowPlayingSource;
     public static Claim nowPlayingClaim;
@@ -667,18 +666,15 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
         // TODO: Check Google Play Services availability
         // Listener here is not called in foss build
-        appBarMediaRouteButton = findViewById(R.id.app_bar_media_route_button);
-        castHelper = new CastHelper(this, appBarMediaRouteButton, new CastHelper.Listener() {
+        castHelper = new CastHelper(this, new CastHelper.Listener() {
             @Override
             public void updateMediaRouteButtonVisibility(boolean isVisible) {
                 mediaRouteButtonVisible = isVisible;
-                appBarMediaRouteButton.setVisibility(isVisible ? View.VISIBLE : View.GONE);
                 if (playerMediaRouteButton != null) {
                     playerMediaRouteButton.setVisibility(isVisible ? View.VISIBLE : View.GONE);
                 }
             }
         });
-        castHelper.setUpCastButton(appBarMediaRouteButton);
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.content_main), new OnApplyWindowInsetsListener() {
             @Override


### PR DESCRIPTION
There is no custom web receiver app so casting is only useful when playing a video.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Other - Please describe: UI Change

## Fixes

Issue Number: N/A

## What is the current behavior?

Cast button introductory overlay is the first thing users see when first opening the app.

## What is the new behavior?

Cast button is only visible within video player.
