### PR TITLE
manifest: add <queries> for VIDEO_CAPTURE intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,12 @@
     package="com.odysee.app"
     android:installLocation="auto">
 
+    <queries>
+        <intent>
+            <action android:name="android.media.action.VIDEO_CAPTURE" />
+        </intent>
+    </queries>
+
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />


### PR DESCRIPTION
Fix "no camera app available to record videos on this device" error.

<details>
<summary>Previous debugging instructions (ignore)</summary>
@tzarebczan please run this (Click Upload then click record, ignore the file loading for now) and either filter for `PublishDebug` in the logcat in Android Studio or run `adb logcat` and filter for lines with `PublishDebug`.

Here's what I get:
```
11-04 16:51:59.357  7097  7097 D PublishDebug: Checking camera permission
11-04 16:51:59.358  7097  7097 D PublishDebug: No camera permission, requesting...
11-04 16:52:04.845  7097  7097 D PublishDebug: About to record (call requestVideoCapture)
11-04 16:52:04.845  7097  7097 D PublishDebug: Requesting video capture
11-04 16:52:04.847  7097  7097 D PublishDebug: Successfully got response from resolveActivity
```
</details>
