### PR TITLE
file view: hide global player if continuing already playing claim

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2355,6 +2355,11 @@ public class FileViewFragment extends BaseFragment implements
                     // claim already playing
                     showExoplayerView();
                     playMedia();
+
+                    Context context = getContext();
+                    if (context instanceof MainActivity) {
+                        ((MainActivity) context).hideGlobalNowPlaying();
+                    }
                 } else {
                     String mediaAutoplay = Objects.requireNonNull((MainActivity) (getActivity())).mediaAutoplayEnabled();
                     if (MainActivity.nowPlayingClaim == null) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Navigating away and going back to same claim makes global player show.

## What is the new behavior?

Hide global player if resuming with same claim.
