### PR TITLE
Sort active livestreams on categories by descending viewers count

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/AllContentFragment.java
@@ -31,6 +31,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -722,6 +723,13 @@ public class AllContentFragment extends BaseFragment implements SharedPreference
                             throw new RuntimeException(e);
                         }
                     }
+
+                    subscribedActiveClaims = subscribedActiveClaims.stream().sorted(new Comparator<Claim>() {
+                        @Override
+                        public int compare(Claim claim, Claim t1) {
+                            return Integer.compare(t1.getLivestreamViewers(), claim.getLivestreamViewers());
+                        }
+                    }).collect(Collectors.toList());
                 } else {
                     a.runOnUiThread(new Runnable() {
                         @Override


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #406 (partial)

## What is the current behavior?
Livestreams on Home page seems randomnly sorted
## What is the new behavior?
They are now sorted by its viewers count