### PR TITLE
Fix some possible MANAGE_EXTERNAL_STORAGE crashes

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -2101,7 +2101,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         initialiseUserInstall();
         // checkPendingOpens();
 
-        checkManageExternalStoragePending();
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+            checkManageExternalStoragePending();
+        }
     }
 
     public void displayCurrentlyPlayingVideo() {
@@ -4028,7 +4030,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 openFragment(PublishFormFragment.class, true, params);
             }
             cameraOutputFilename = null;
-        } else if (requestCode == REQUEST_MANAGE_STORAGE_PERMISSION) {
+        } else if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q && requestCode == REQUEST_MANAGE_STORAGE_PERMISSION) {
             if (resultCode == RESULT_OK && Environment.isExternalStorageManager()) {
                 for (StoragePermissionListener listener : storagePermissionListeners) {
                     listener.onManageExternalStoragePermissionGranted();
@@ -4041,6 +4043,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         }
     }
 
+    @TargetApi(Build.VERSION_CODES.R)
     private void checkManageExternalStoragePending() {
         if (!manageExternalStoragePending) {
             return;

--- a/app/src/main/java/com/odysee/app/ui/publish/PublishFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/publish/PublishFragment.java
@@ -2,6 +2,8 @@ package com.odysee.app.ui.publish;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -35,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import com.odysee.app.BuildConfig;
 import com.odysee.app.MainActivity;
 import com.odysee.app.R;
 import com.odysee.app.adapter.GalleryGridAdapter;
@@ -442,16 +443,20 @@ public class PublishFragment extends BaseFragment implements
         }
     }
 
+    @TargetApi(Build.VERSION_CODES.TIRAMISU)
     private void requestManageExternalStorage() {
-        try {
-            // if for some reason, the package uri
-            Uri packageUri = Uri.parse("package:" + BuildConfig.APPLICATION_ID);
-            Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, packageUri);
-            startActivityForResult(intent, MainActivity.REQUEST_MANAGE_STORAGE_PERMISSION);
-        } catch (Exception ex){
-            // If for some reason, the package uri was not found and it results in an error, show the screen for all permissions
-            Intent intent = new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
-            startActivityForResult(intent, MainActivity.REQUEST_MANAGE_STORAGE_PERMISSION);
+        Activity activity = getActivity();
+        if (activity != null) {
+            try {
+                // if for some reason, the package uri
+                Uri packageUri = Uri.parse("package:" + activity.getPackageName());
+                Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, packageUri);
+                startActivityForResult(intent, MainActivity.REQUEST_MANAGE_STORAGE_PERMISSION);
+            } catch (Exception ex){
+                // If for some reason, the package uri was not found and it results in an error, show the screen for all permissions
+                Intent intent = new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+                startActivityForResult(intent, MainActivity.REQUEST_MANAGE_STORAGE_PERMISSION);
+            }
         }
     }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
App could crash when calling some methods not available to prior Android API Levels
## What is the new behavior?
A check is implemented to avoid the crash