### PR TITLE
file view player: auto exit fullscreen when switching to portrait

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -1079,7 +1079,6 @@ public class FileViewFragment extends BaseFragment implements
             activity.removePIPModeListener(this);
             activity.removeScreenOrientationListener(this);
             activity.removeStoragePermissionListener(this);
-            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
             activity.showAppBar();
             activity.checkNowPlaying();
 
@@ -3942,8 +3941,6 @@ public class FileViewFragment extends BaseFragment implements
                 activity.enterFullScreenMode();
 
                 exoplayerContainer.setPadding(0, 0, 0, 0);
-
-                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
             }
         }
     }
@@ -3963,7 +3960,6 @@ public class FileViewFragment extends BaseFragment implements
                 exoplayerContainer.setPadding(0, 0, 0, 0);
 
                 activity.exitFullScreenMode();
-                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
             }
         }
     }
@@ -4162,11 +4158,10 @@ public class FileViewFragment extends BaseFragment implements
 
     @Override
     public void onPortraitOrientationEntered() {
-        // Skip this for now. User restores default view mode by pressing fullscreen toggle
-        /*Context context = getContext();
+        Context context = getContext();
         if (context instanceof MainActivity && ((MainActivity) context).isInFullscreenMode()) {
             disableFullScreenMode();
-        }*/
+        }
     }
 
     @Override


### PR DESCRIPTION
This reverts the orientation lock (preventing the player from leaving fullscreen) added in
https://github.com/lbryio/lbry-android/commit/540a8412.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Player doesn't exit fullscreen when rotating phone, orientation locked in landscape when player is in fullscreen.

## What is the new behavior?

Remove orientation lock, automatically exit fullscreen when rotating to portrait.

## Other information

I tested this with the situation I'm assuming was described in https://github.com/lbryio/lbry-android/commit/540a8412, i.e. going to/from the global PiP player when in fullscreen mode.
