### PR TITLE
Replace some more newSingleThreadExeutor usages

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -164,8 +164,6 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -637,7 +635,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         }
 
         dbHelper = new DatabaseHelper(this);
-        Executors.newSingleThreadExecutor().execute(new Runnable() {
+        ((OdyseeApp) getApplication()).getExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 SQLiteDatabase db = dbHelper.getWritableDatabase();
@@ -4954,7 +4952,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     public void handleAddUrlToList(String url, OdyseeCollection collection, boolean showMessage) {
-        Executors.newSingleThreadExecutor().execute(new Runnable() {
+        ((OdyseeApp) getApplication()).getExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -4990,8 +4988,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     public void handleSaveCollection(final OdyseeCollection collection) {
-        ExecutorService executor = ((OdyseeApp) getApplication()).getExecutor();
-        executor.execute(new Runnable() {
+        ((OdyseeApp) getApplication()).getExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -5025,7 +5022,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     public void handleRemoveUrlFromList(String url, OdyseeCollection collection) {
-        Executors.newSingleThreadExecutor().execute(new Runnable() {
+        ((OdyseeApp) getApplication()).getExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -5089,7 +5086,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             return;
         }
 
-        Executors.newSingleThreadExecutor().execute(new Runnable() {
+        ((OdyseeApp) getApplication()).getExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 try {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Refactoring (no functional changes)

## What is the current behavior?
Executors.newSingleThreadExecutor() creates a new executor, which is an expensive task
## What is the new behavior?
This usages have been replaced by the executor which application object creates on the first request.