### PR TITLE
Add some comments for desugaring library on build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
     flavorDimensions "default"
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
+        coreLibraryDesugaringEnabled true // TODO Switch this to false when minSDKVersion is 26 or higher
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -70,6 +70,7 @@ configurations {
 dependencies {
     testImplementation project(path: ':app')
 //    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    // Version 1.1.5 is the last one for desugar-jdk-libs which can be used with Android Gradle Plugin 6
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     implementation 'androidx.appcompat:appcompat:1.3.1'


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Documentation changes

## Other information
Desugaring allows for Java classes not defined in older Android versions to be available. Currently, the Instant Java class is used on the project but this was not defined until Android API Level 26.

This PR adds a few comments to build.gradle for when minimum SDK version changes to 26 so whoever makes that change, disables desugaring.

Also, desugaring library versions 1.2 needs a newer AGP than the one Odysee Android is using. Gradle is flaging 1.1.5 as an old one. This PR is also adding a comment so noone loses its time trying to update that version, as it won't build until AGP is also upgraded to 7+
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
