### PR TITLE
Show sign up verification email address

### DIFF
--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -144,6 +144,7 @@
         android:layout_centerVertical="true"
         android:layout_margin="36dp"
         android:orientation="vertical"
+        tools:visibility="visible"
         android:visibility="gone">
 
         <TextView
@@ -171,6 +172,7 @@
             android:ellipsize="middle"
             android:singleLine="true"
             android:textAlignment="center"
+            tools:text="example@example.org"
             android:textColor="@color/title_text"
             style="@style/TextView_Light"
             android:textSize="20sp" />


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
When user tries to sign up for the first time on Odysee Android, an email message is sent to the new user. UI updates to show to say user that a message has been sent to the address, but no address is being displayed.

This only happens for new email addresses. If user tries to sign in with an existing user account, the address is shown as expected.
## What is the new behavior?
User sees to which address the message has been sent. This way it is possible to edit it if user realizes that the address was wrong, like with a typo for example
## Other information
Additionally, global executors are being used here instead of newly created ones. I saw the UI problem with the email address while searching for "executor" on the prohect source code.
