### PR TITLE
Set text color to white on MaterialButtons

### DIFF
--- a/app/src/full/res/layout/fragment_reward_verification_paid.xml
+++ b/app/src/full/res/layout/fragment_reward_verification_paid.xml
@@ -24,6 +24,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:fontFamily="@font/inter"
+        android:textColor="@color/white"
         android:text="@string/skip_queue_button_text" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/full/res/layout/fragment_reward_verification_twitter.xml
+++ b/app/src/full/res/layout/fragment_reward_verification_twitter.xml
@@ -23,6 +23,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:fontFamily="@font/inter"
+            android:textColor="@color/white"
             android:text="@string/twitter_verify" />
     </androidx.appcompat.widget.LinearLayoutCompat>
     <RelativeLayout

--- a/app/src/main/res/layout/activity_go_live.xml
+++ b/app/src/main/res/layout/activity_go_live.xml
@@ -21,6 +21,7 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="32dp"
         android:layout_marginBottom="32dp"
+        android:textColor="@color/white"
         android:text="@string/start_streaming"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -197,6 +197,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="3"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/resend" />
 
             <View
@@ -311,6 +312,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/done" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/card_invites_by_email.xml
+++ b/app/src/main/res/layout/card_invites_by_email.xml
@@ -55,6 +55,7 @@
                 android:layout_alignParentEnd="true"
                 android:enabled="false"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/invite" />
         </RelativeLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/card_wallet_send_credits.xml
+++ b/app/src/main/res/layout/card_wallet_send_credits.xml
@@ -106,6 +106,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/send" />
         </RelativeLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/channel_form_bottom_sheet.xml
+++ b/app/src/main/res/layout/channel_form_bottom_sheet.xml
@@ -134,6 +134,7 @@
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             android:fontFamily="@font/inter"
+            android:textColor="@color/white"
             android:text="@string/create"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/container_comment_form.xml
+++ b/app/src/main/res/layout/container_comment_form.xml
@@ -173,6 +173,7 @@
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/comment_form_post" />
             <ProgressBar
                 android:id="@+id/comment_form_post_progress"
@@ -200,6 +201,7 @@
         <com.google.android.material.button.MaterialButton android:id="@+id/create_channel_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textColor="@color/white"
             android:text="@string/create_a_channel" />
     </LinearLayout>
     <LinearLayout android:id="@+id/user_not_signed_in"
@@ -218,6 +220,7 @@
         <com.google.android.material.button.MaterialButton android:id="@+id/sign_in_user_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textColor="@color/white"
             android:text="@string/sign_in" />
     </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/container_nothing_at_location.xml
+++ b/app/src/main/res/layout/container_nothing_at_location.xml
@@ -35,6 +35,7 @@
             android:layout_marginTop="24dp"
             style="@style/TextView_Light"
             android:textSize="14sp"
+            android:textColor="@color/white"
             android:text="@string/publish_something_here"
             android:visibility="gone" />
     </LinearLayout>

--- a/app/src/main/res/layout/dialog_create_support.xml
+++ b/app/src/main/res/layout/dialog_create_support.xml
@@ -152,6 +152,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:layout_alignParentEnd="true"
                 android:layout_centerVertical="true" />
         </RelativeLayout>

--- a/app/src/main/res/layout/dialog_customize_tags.xml
+++ b/app/src/main/res/layout/dialog_customize_tags.xml
@@ -98,6 +98,7 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="16dp"
             android:fontFamily="@font/inter"
-            android:text="@string/done" />
+            android:text="@string/done"
+            android:textColor="@color/white" />
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_discover.xml
+++ b/app/src/main/res/layout/dialog_discover.xml
@@ -48,6 +48,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:fontFamily="@font/inter"
-        android:text="@string/done" />
+        android:text="@string/done"
+        android:textColor="@color/white" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/dialog_edit_comment.xml
+++ b/app/src/main/res/layout/dialog_edit_comment.xml
@@ -14,6 +14,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:fontFamily="@font/inter"
+        android:textColor="@color/white"
         android:text="@string/done"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/dialog_playlists.xml
+++ b/app/src/main/res/layout/dialog_playlists.xml
@@ -92,6 +92,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
                 android:layout_marginEnd="10dp"
+                android:textColor="@color/white"
                 android:text="@string/done"
                 app:icon="@drawable/ic_check" />
         </RelativeLayout>

--- a/app/src/main/res/layout/dialog_publish_playlist.xml
+++ b/app/src/main/res/layout/dialog_publish_playlist.xml
@@ -221,7 +221,8 @@
                 android:layout_alignParentEnd="true"
                 android:layout_centerVertical="true"
                 android:fontFamily="@font/inter"
-                android:text="@string/publish" />
+                android:text="@string/publish"
+                android:textColor="@color/white" />
         </RelativeLayout>
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_repost_claim.xml
+++ b/app/src/main/res/layout/dialog_repost_claim.xml
@@ -176,6 +176,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/repost"
                 android:layout_alignParentEnd="true"
                 android:layout_centerVertical="true" />

--- a/app/src/main/res/layout/fragment_channel_form.xml
+++ b/app/src/main/res/layout/fragment_channel_form.xml
@@ -340,6 +340,7 @@
                             android:layout_alignParentEnd="true"
                             android:layout_centerVertical="true"
                             android:fontFamily="@font/inter"
+                            android:textColor="@color/white"
                             android:text="@string/save" />
                     </RelativeLayout>
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_channel_manager.xml
+++ b/app/src/main/res/layout/fragment_channel_manager.xml
@@ -57,6 +57,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/create_a_channel"  />
         </LinearLayout>
     </RelativeLayout>

--- a/app/src/main/res/layout/fragment_creator_settings.xml
+++ b/app/src/main/res/layout/fragment_creator_settings.xml
@@ -304,6 +304,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:textColor="@color/white"
                     android:text="@string/add_moderator"
                     android:fontFamily="@font/inter"
                     android:textSize="12sp" />
@@ -365,6 +366,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:textColor="@color/white"
                     android:text="@string/add_words"
                     android:fontFamily="@font/inter"
                     android:textSize="12sp" />

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -80,6 +80,7 @@
                     android:layout_height="wrap_content"
                     android:layout_centerInParent="true"
                     android:fontFamily="@font/inter"
+                    android:textColor="@color/white"
                     android:text="@string/play"
                     android:textSize="14sp"
                     android:visibility="invisible" />
@@ -239,6 +240,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:fontFamily="@font/inter"
+                        android:textColor="@color/white"
                         android:text="@string/open"
                         android:textSize="14sp" />
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_go_live_form.xml
+++ b/app/src/main/res/layout/fragment_go_live_form.xml
@@ -631,6 +631,7 @@
                     android:layout_alignParentEnd="true"
                     android:layout_centerVertical="true"
                     android:fontFamily="@font/inter"
+                    android:textColor="@color/white"
                     android:text="@string/create" />
             </RelativeLayout>
             <!-- endregion -->

--- a/app/src/main/res/layout/fragment_invites.xml
+++ b/app/src/main/res/layout/fragment_invites.xml
@@ -81,6 +81,7 @@
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/get_started" />
         </RelativeLayout>
     </RelativeLayout>

--- a/app/src/main/res/layout/fragment_livestreams.xml
+++ b/app/src/main/res/layout/fragment_livestreams.xml
@@ -114,6 +114,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:enabled="false"
+            android:textColor="@color/white"
             android:text="@string/start_streaming"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
@@ -170,6 +171,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     android:fontFamily="@font/inter"
+                    android:textColor="@color/white"
                     android:text="@string/create_livestream"  />
             </LinearLayout>
         </RelativeLayout>

--- a/app/src/main/res/layout/fragment_publish_form.xml
+++ b/app/src/main/res/layout/fragment_publish_form.xml
@@ -643,6 +643,7 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentEnd="true"
                     android:layout_centerVertical="true"
+                    android:textColor="@color/white"
                     android:fontFamily="@font/inter"
                     android:text="@string/publish" />
             </RelativeLayout>

--- a/app/src/main/res/layout/fragment_publishes.xml
+++ b/app/src/main/res/layout/fragment_publishes.xml
@@ -49,6 +49,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/new_publish"  />
         </LinearLayout>
     </RelativeLayout>

--- a/app/src/main/res/layout/fragment_sign_in.xml
+++ b/app/src/main/res/layout/fragment_sign_in.xml
@@ -186,6 +186,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="3"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/resend" />
 
             <View
@@ -300,6 +301,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/done" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_verification_email.xml
+++ b/app/src/main/res/layout/fragment_verification_email.xml
@@ -59,6 +59,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/continue_text" />
             <ProgressBar
                 android:id="@+id/verification_email_add_progress"
@@ -127,6 +128,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/resend" />
 
             <View

--- a/app/src/main/res/layout/fragment_verification_manual.xml
+++ b/app/src/main/res/layout/fragment_verification_manual.xml
@@ -61,6 +61,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/twitter_verify" />
 
 
@@ -86,6 +87,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/phone_number_verify" />
 
             <TextView
@@ -110,6 +112,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/skip_queue_button_text" />
             <TextView
                 android:layout_width="match_parent"
@@ -125,6 +128,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/verify_purchase" />
 
             <TextView
@@ -160,6 +164,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/continue_text" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_verification_phone.xml
+++ b/app/src/main/res/layout/fragment_verification_phone.xml
@@ -57,6 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/continue_text" />
             <ProgressBar
                 android:id="@+id/verification_phone_new_progress"
@@ -116,6 +117,7 @@
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/verify" />
             <ProgressBar
                 android:id="@+id/verification_phone_verify_progress"

--- a/app/src/main/res/layout/fragment_verification_wallet.xml
+++ b/app/src/main/res/layout/fragment_verification_wallet.xml
@@ -100,6 +100,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:fontFamily="@font/inter"
+                android:textColor="@color/white"
                 android:text="@string/done" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_youtube_sync_setup.xml
+++ b/app/src/main/res/layout/fragment_youtube_sync_setup.xml
@@ -100,6 +100,7 @@
                     android:layout_alignParentEnd="true"
                     android:enabled="false"
                     android:fontFamily="@font/inter"
+                    android:textColor="@color/white"
                     android:text="@string/claim_now" />
 
                 <ProgressBar

--- a/app/src/main/res/layout/fragment_youtube_sync_status.xml
+++ b/app/src/main/res/layout/fragment_youtube_sync_status.xml
@@ -69,6 +69,7 @@
             android:layout_marginLeft="36dp"
             android:layout_marginRight="36dp"
             android:layout_marginBottom="24dp"
+            android:textColor="@color/white"
             android:text="@string/claim_channel" />
 
         <TextView

--- a/app/src/main/res/layout/list_item_channel.xml
+++ b/app/src/main/res/layout/list_item_channel.xml
@@ -252,6 +252,7 @@
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/inter"
                     android:textSize="12sp"
+                    android:textColor="@color/white"
                     android:text="@string/unblock" />
             </androidx.appcompat.widget.LinearLayoutCompat>
         </LinearLayout>

--- a/app/src/main/res/layout/list_item_reward.xml
+++ b/app/src/main/res/layout/list_item_reward.xml
@@ -87,6 +87,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
+                android:textColor="@color/white"
                 android:text="@string/claim"
                 android:fontFamily="@font/inter"
                 style="@style/TextView_Light"

--- a/app/src/main/res/layout/popup_user.xml
+++ b/app/src/main/res/layout/popup_user.xml
@@ -49,6 +49,7 @@
             android:layout_marginRight="12dp"
             android:layout_marginEnd="12dp"
             android:layout_marginBottom="4dp"
+            android:textColor="@color/white"
             android:text="@string/sign_up_log_in"/>
 
         <RelativeLayout

--- a/app/src/main/res/layout/popup_webview.xml
+++ b/app/src/main/res/layout/popup_webview.xml
@@ -17,5 +17,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
+        android:textColor="@color/white"
         android:text="@string/cancel" />
 </RelativeLayout>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
As buttons color is set to the primary brand color, when Android framework draws it and uses black for text color, there is not enogh contrast.
## What is the new behavior?
Forcing color to always be white makes text readable in all conditions