### PR TITLE
file view: hide mini player and fix player after download picked

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -1001,9 +1001,15 @@ public class FileViewFragment extends BaseFragment implements
     public void onResume() {
         super.onResume();
 
+        Context context = getContext();
+
         // Skip init if resuming from file picker
         if (startingFilePicker) {
             startingFilePicker = MainActivity.startingFilePickerActivity;
+            setPlayerForPlayerView();
+            if (context instanceof MainActivity) {
+                ((MainActivity) context).hideGlobalNowPlaying();
+            }
             return;
         }
 
@@ -1014,7 +1020,6 @@ public class FileViewFragment extends BaseFragment implements
             checkWebSocketClient();
         }
 
-        Context context = getContext();
         Helper.setWunderbarValue(currentUrl, context);
         Claim actualClaim = collectionClaimItem != null ? collectionClaimItem : fileClaim;
         if (context instanceof MainActivity) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A

## What is the current behavior?

Miniplayer shown and main player doesn't show video after picking location to download to.

## What is the new behavior?

Hide miniplayer, call `setPlayerForPlayerView()` which unsets and sets the PlayerView's player so it shows video.
