### PR TITLE
claim_search: filter unlisted and future scheduled

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
@@ -234,10 +234,6 @@ public class ChannelContentFragment extends Fragment implements SharedPreference
             PreferenceManager.getDefaultSharedPreferences(context).registerOnSharedPreferenceChangeListener(this);
         }
 
-        if (contentReleaseTime == null) {
-            String relTime = String.valueOf(Double.valueOf(Math.floor(System.currentTimeMillis()) / 1000.0).intValue());
-            contentReleaseTime = "<=" + relTime;
-        }
         fetchClaimSearchContent();
     }
 

--- a/app/src/main/java/com/odysee/app/utils/Lbry.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbry.java
@@ -13,6 +13,7 @@ import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -410,14 +411,18 @@ public final class Lbry {
         }
         options.put("page", page);
         options.put("page_size", pageSize);
-        if (!Helper.isNullOrEmpty(releaseTime)) {
-            options.put("release_time", releaseTime);
-        }
+
         if (maxDuration > 0) {
             options.put("duration", String.format("<%d", maxDuration));
         }
         if (limitClaimsPerChannel > 0) {
             options.put("limit_claims_per_channel", limitClaimsPerChannel);
+        }
+
+        if (notTags != null) {
+            notTags.add("c:unlisted");
+        } else {
+            notTags = Collections.singletonList("c:unlisted");
         }
 
         addClaimSearchListOption("any_tags", anyTags, options);
@@ -426,6 +431,13 @@ public final class Lbry {
         addClaimSearchListOption("channel_ids", channelIds, options);
         addClaimSearchListOption("not_channel_ids", notChannelIds, options);
         addClaimSearchListOption("order_by", orderBy, options);
+
+        String releaseTimeBeforeFuture =
+                String.valueOf(Double.valueOf(Math.floor(System.currentTimeMillis()) / 1000.0).intValue());
+        List<String> releaseTimeList = releaseTime != null ?
+                Arrays.asList(releaseTime, "<" + releaseTimeBeforeFuture) :
+                Collections.singletonList("<" + releaseTimeBeforeFuture);
+        addClaimSearchListOption("release_time", releaseTimeList, options);
 
         return options;
     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Fix: #421

## What is the current behavior?

Claims with `c:unlisted` and/or a release time in the future (future scheduled) are still shown.

## What is the new behavior?

Add `c:unlisted` to `not_tags` and add "release time < now()" for `claim_search` calls.
