### PR TITLE
file view: show unsupported content view, fix download toasts

### DIFF
--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -236,12 +236,12 @@
                         android:textSize="14sp" />
 
                     <com.google.android.material.button.MaterialButton
-                        android:id="@+id/file_view_open_external_button"
+                        android:id="@+id/file_view_download_unsuported_button"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:fontFamily="@font/inter"
                         android:textColor="@color/white"
-                        android:text="@string/open"
+                        android:text="@string/download"
                         android:textSize="14sp" />
                 </LinearLayout>
             </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,7 +166,7 @@
     <string name="view">View</string>
     <string name="play">Play</string>
     <string name="unsupported_content">Unsupported Content</string>
-    <string name="unsupported_content_desc">Sorry, we are unable to display this content in the app. You can find the file %1$sin your downloads folder.</string>
+    <string name="unsupported_content_desc">Sorry, we are unable to display this content in the app. You can download the file instead.</string>
     <string name="nothing_at_this_location">There\'s nothing at this location.</string>
     <string name="dmca_complaint_blocked">In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this content from our applications. &lt;a href="https://lbry.com/faq/dmca"&gt;Read more&lt;/a&gt;</string>
     <string name="dmca_complaint_channel_blocked">In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this channel from our applications. &lt;a href="https://lbry.com/faq/dmca"&gt;Read more&lt;/a&gt;</string>


### PR DESCRIPTION
If content is neither playable or viewable, show unsupported content view with button to download the file.

Shut down scheduler used for observing download progress on error or manual abort. This fixes error/success toasts being repeatedly shown. (To get the success toast to repeatedly show, start a download, abort it, then download again).

Also set downloadInProgress to false after download completes successfully.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: N/A
