### PR TITLE
Fix crash when back-button is pressed

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -3828,13 +3828,14 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     findViewById(R.id.fragment_container_main_activity).setVisibility(View.VISIBLE);
                     showBottomNavigation();
                 }
-                findViewById(R.id.title).setVisibility(View.GONE);
-                findViewById(R.id.toolbar_balance_and_tools_layout).setVisibility(View.VISIBLE);
 
                 ActionBar actionBar = getSupportActionBar();
                 if (actionBar != null) {
+                    findViewById(R.id.title).setVisibility(View.GONE);
+                    findViewById(R.id.toolbar_balance_and_tools_layout).setVisibility(View.VISIBLE);
+
                     showActionBar();
-                    getSupportActionBar().setDisplayHomeAsUpEnabled(false);
+                    actionBar.setDisplayHomeAsUpEnabled(false);
                 }
             }
         } else if (!enterPIPMode()) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
In some situations, app crashes after user has pressed device's back button
## What is the new behavior?
App will not crash
## Other information
The fix consists in moving title and "balance and tools layout" to a conditional branch. Those views are part of the toolbar which, from the OS point-of-view, is the action bar. If there is no action bar at that point, those views cannot be accessed, causing the crash.